### PR TITLE
Fix build of back-end plugin

### DIFF
--- a/Magefile.go
+++ b/Magefile.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"github.com/magefile/mage/mg"
 	"github.com/magefile/mage/sh"
+	"runtime"
 )
 
 const dsName string = "sheets-datasource"
@@ -37,7 +38,8 @@ type Build mg.Namespace
 
 // Backend builds the back-end plugin.
 func (Build) Backend() error {
-	return buildBackend("", false, map[string]string{})
+	variant := fmt.Sprintf("%s_%s", runtime.GOOS, runtime.GOARCH)
+	return buildBackend(variant, false, map[string]string{})
 }
 
 // BackendDebug builds the back-end plugin in debug mode.

--- a/scripts/restart-plugin.sh
+++ b/scripts/restart-plugin.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 set -eo pipefail
 
-make build
+mage buildAll
 docker exec google-sheets-datasource_grafana_1 pkill -f "/var/lib/grafana/plugins/google-sheets-datasource/dist/sheets-datasource_linux_amd64"


### PR DESCRIPTION
Fix Magefile.go, the back-end plugin executable needs to have OS and arch in its filename. Because of this we remove the build:backend target, since it will overlap with build:backendLinux. Also ensure that front-end is built first, since it wipes the whole dist/ directory (along with back-end executable).

 Also fixes the restart-plugin.sh script.