### PR TITLE
Magefile: Build back-end and front-end in parallel; add clean target

### DIFF
--- a/Magefile.go
+++ b/Magefile.go
@@ -4,6 +4,7 @@ package main
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/magefile/mage/mg"
 	"github.com/magefile/mage/sh"
@@ -54,8 +55,7 @@ func (Build) BackendLinuxDebug() error {
 	return buildBackend("linux_amd64", true, env)
 }
 
-// Frontend builds the front-end for production.  Note that this build script will also
-// clean the `dist` folder.
+// Frontend builds the front-end for production.
 func (Build) Frontend() error {
 	mg.Deps(Deps)
 	return sh.RunV("./node_modules/.bin/grafana-toolkit", "plugin:build")
@@ -64,8 +64,7 @@ func (Build) Frontend() error {
 // BuildAll builds both back-end and front-end components.
 func BuildAll() {
 	b := Build{}
-	// Frontend goes first and cleans the 'dist' folder
-	mg.Deps(b.Frontend, b.BackendLinux)
+	mg.Deps(b.BackendLinux, b.Frontend)
 }
 
 // Deps installs dependencies.
@@ -119,6 +118,11 @@ func Watch() error {
 
 	// The --watch will never return
 	return sh.RunV("./node_modules/.bin/grafana-toolkit", "plugin:dev", "--watch")
+}
+
+// Clean cleans build artifacts, by deleting the dist directory.
+func Clean() error {
+	return os.RemoveAll("dist")
 }
 
 // Default configures the default target.

--- a/Magefile.go
+++ b/Magefile.go
@@ -61,6 +61,12 @@ func (Build) Frontend() error {
 	return sh.RunV("./node_modules/.bin/grafana-toolkit", "plugin:build")
 }
 
+// FrontendDev builds the front-end for development.
+func (Build) FrontendDev() error {
+	mg.Deps(Deps)
+	return sh.RunV("./node_modules/.bin/grafana-toolkit", "plugin:dev")
+}
+
 // BuildAll builds both back-end and front-end components.
 func BuildAll() {
 	b := Build{}
@@ -99,15 +105,7 @@ func Format() error {
 // Dev builds the plugin in dev mode.
 func Dev() error {
 	b := Build{}
-
-	// First build the frontend
-	if err := sh.RunV("./node_modules/.bin/grafana-toolkit", "plugin:dev"); err != nil {
-		return err
-	}
-
-	// Then a debug backend
-	mg.Deps(b.BackendLinuxDebug) // TODO: only the current architecture
-
+	mg.Deps(b.BackendLinuxDebug, b.FrontendDev) // TODO: only the current architecture
 	return nil
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -913,16 +913,16 @@
   resolved "https://registry.yarnpkg.com/@emotion/weak-memoize/-/weak-memoize-0.2.5.tgz#8eed982e2ee6f7f4e44c253e12962980791efd46"
   integrity sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA==
 
-"@grafana/data@6.7.0-pre-cc638e81f4", "@grafana/data@canary":
-  version "6.7.0-pre-cc638e81f4"
-  resolved "https://registry.yarnpkg.com/@grafana/data/-/data-6.7.0-pre-cc638e81f4.tgz#b9e18dab580242f8443429a8d7df8302e8c41455"
-  integrity sha512-QVI79sIEeKxN2mcosQqECtIx+ih0yoxkOg1cvptnF7E64SnAJ6quVE1oh1TP/u1dkP3tZECEVy4OcKz8pMSHug==
+"@grafana/data@6.7.0-pre-f09ee3d8c2", "@grafana/data@canary":
+  version "6.7.0-pre-f09ee3d8c2"
+  resolved "https://registry.yarnpkg.com/@grafana/data/-/data-6.7.0-pre-f09ee3d8c2.tgz#98753e24f031c8546ee7921ffa302742e5641b3f"
+  integrity sha512-BFphUWyK7BmVcJz/DzGcY5beF5I16IXO9hsoEy1VW8XMfttTNugJDVUkc/QoMJ5K4UsBk/mpgnsQzL4kDzahvQ==
   dependencies:
     apache-arrow "0.15.1"
     lodash "4.17.15"
     rxjs "6.5.4"
 
-"@grafana/data@6.7.0-pre-ff6a082e23", "@grafana/data@^6.7.0-pre-cc638e81f4":
+"@grafana/data@6.7.0-pre-ff6a082e23", "@grafana/data@^6.7.0-pre-f09ee3d8c2":
   version "6.7.0-pre-ff6a082e23"
   resolved "https://registry.yarnpkg.com/@grafana/data/-/data-6.7.0-pre-ff6a082e23.tgz#26d7c928a5dc21bb8b830fa038a1c073b9df5eec"
   integrity sha512-hFreGvFPFoRpYccJfTbwYxle3mxPD7Rh6VN8WutFnz+TMQuT8uZcHSSsTnE9VwbPPWh6x5u2hPinmmQiSFuVWQ==
@@ -933,12 +933,12 @@
   integrity sha512-xmcJR6mUYw1llq3m8gT2kE7xoq6yLMUgNf2Mf1yZvDCx2cXFSyaLlGs1dqjFWjJDbV46GdhYRAyRbyGR+J9QKg==
 
 "@grafana/runtime@canary":
-  version "6.7.0-pre-cc638e81f4"
-  resolved "https://registry.yarnpkg.com/@grafana/runtime/-/runtime-6.7.0-pre-cc638e81f4.tgz#eba3d5c0b2263f50db07a8e225e8b9d1f42262cb"
-  integrity sha512-5CwjfcmcNb3msUF1nYT8w+SL3ZBobaeJ+Layo61gK0JRO7q4THLjG2sShxXuvX2/ZcCbOCCsa9OYbOOgazjUXA==
+  version "6.7.0-pre-f09ee3d8c2"
+  resolved "https://registry.yarnpkg.com/@grafana/runtime/-/runtime-6.7.0-pre-f09ee3d8c2.tgz#d1d75df19cf29638750684b60c8e317e090144b6"
+  integrity sha512-rIRHgWBCytVFtwlXkg6XLsYkyKNT6nRoLO/mazzwbrluDqf6mMhQx6TKapOGLvuGLrgqPbSDltbaLzDgAD8x3w==
   dependencies:
-    "@grafana/data" "6.7.0-pre-cc638e81f4"
-    "@grafana/ui" "6.7.0-pre-cc638e81f4"
+    "@grafana/data" "6.7.0-pre-f09ee3d8c2"
+    "@grafana/ui" "6.7.0-pre-f09ee3d8c2"
     systemjs "0.20.19"
     systemjs-plugin-css "0.1.37"
 
@@ -965,16 +965,16 @@
     tiny-warning "^0.0.3"
 
 "@grafana/toolkit@canary":
-  version "6.7.0-pre-cc638e81f4"
-  resolved "https://registry.yarnpkg.com/@grafana/toolkit/-/toolkit-6.7.0-pre-cc638e81f4.tgz#a43f1fdcbd751ffd3f7ccc63ffd7e2aec4351680"
-  integrity sha512-hpK9g2Raq9oSDBgt0fMWJX+rLnkr9frbEmL4Td9Vh028HxBN+1u8J0E5b+DNUtp1rXv2hb9KQfFU4PgbAJZcMA==
+  version "6.7.0-pre-f09ee3d8c2"
+  resolved "https://registry.yarnpkg.com/@grafana/toolkit/-/toolkit-6.7.0-pre-f09ee3d8c2.tgz#443628e8f5494a15a359ceb080cc5ff6ca625523"
+  integrity sha512-y5IYwmpKoM9eKhIasvX0lb01XbTbqJJ57q3xAYgGgUcyKZ+oPlpvKjsTGs8jd3Bfq33mLeCuRIY/Z9DNaBTqSQ==
   dependencies:
     "@babel/core" "7.8.3"
     "@babel/preset-env" "7.8.3"
-    "@grafana/data" "^6.7.0-pre-cc638e81f4"
+    "@grafana/data" "^6.7.0-pre-f09ee3d8c2"
     "@grafana/eslint-config" "^1.0.0-rc1"
     "@grafana/tsconfig" "^1.0.0-rc1"
-    "@grafana/ui" "^6.7.0-pre-cc638e81f4"
+    "@grafana/ui" "^6.7.0-pre-f09ee3d8c2"
     "@types/command-exists" "^1.2.0"
     "@types/execa" "^0.9.0"
     "@types/expect-puppeteer" "3.3.1"
@@ -1054,13 +1054,13 @@
   resolved "https://registry.yarnpkg.com/@grafana/tsconfig/-/tsconfig-1.0.0-rc1.tgz#d07ea16755a50cae21000113f30546b61647a200"
   integrity sha512-nucKPGyzlSKYSiJk5RA8GzMdVWhdYNdF+Hh65AXxjD9PlY69JKr5wANj8bVdQboag6dgg0BFKqgKPyY+YtV4Iw==
 
-"@grafana/ui@6.7.0-pre-cc638e81f4", "@grafana/ui@canary":
-  version "6.7.0-pre-cc638e81f4"
-  resolved "https://registry.yarnpkg.com/@grafana/ui/-/ui-6.7.0-pre-cc638e81f4.tgz#5d3cf86e0c66753bba87056c6d18fff664e4fef7"
-  integrity sha512-gP18YOAc3w2qtQCmmxtAOrlQz+mQ3RWQg+NKvHatiXdTkyse3+oX/Sxg9Nqb6RFqa/BSImp+yUeAZXnR4VHRPA==
+"@grafana/ui@6.7.0-pre-f09ee3d8c2", "@grafana/ui@canary":
+  version "6.7.0-pre-f09ee3d8c2"
+  resolved "https://registry.yarnpkg.com/@grafana/ui/-/ui-6.7.0-pre-f09ee3d8c2.tgz#7cb018f48726ddd14ff455c8130650411e5fcbf9"
+  integrity sha512-7XAxmORAl0M0yXLQ/Kx1sG9ARThZhCXxWK6ZM3nSpThw3XHIRRUnW1PyFoPbFXN0hsX1KzUYlD7Tj+RxzvLBvw==
   dependencies:
     "@emotion/core" "^10.0.27"
-    "@grafana/data" "6.7.0-pre-cc638e81f4"
+    "@grafana/data" "6.7.0-pre-f09ee3d8c2"
     "@grafana/slate-react" "0.22.9-grafana"
     "@grafana/tsconfig" "^1.0.0-rc1"
     "@torkelo/react-select" "3.0.8"
@@ -1096,7 +1096,7 @@
     slate "0.47.8"
     tinycolor2 "1.4.1"
 
-"@grafana/ui@^6.7.0-pre-cc638e81f4":
+"@grafana/ui@^6.7.0-pre-f09ee3d8c2":
   version "6.7.0-pre-ff6a082e23"
   resolved "https://registry.yarnpkg.com/@grafana/ui/-/ui-6.7.0-pre-ff6a082e23.tgz#1a4addb560d3b77da931719ef28845ff5d23a547"
   integrity sha512-D9vArWeFEMnRFt4vB6b3KGt8mVcUtUUuspdfHB+MMnwFiDb5moartSi9TI2NY+moDwwIopeAi7XR9RLD8RDpcA==


### PR DESCRIPTION
Since grafana-toolkit has been fixed to not wipe the dist directory, build front-end and back-end in parallel (I've verified that it works). Also add "clean" target to Magefile.