### PR TITLE
clearing cache by default in step 1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -116,8 +116,7 @@ jobs:
         - ci/grafana-test-env
 
   test_integration:
-    docker:
-    - image: circleci/node:12-browsers
+    <<: *defaults
     steps:
     - checkout
     - attach_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -129,7 +129,7 @@ jobs:
     - run:
         name: Setup Grafana (local install)
         command: |
-          sudo dpkg -i /usr/local/grafana/grafana_6.6.3_amd64.deb
+          sudo dpkg -i /usr/local/grafana/grafana_6.6.2_amd64.deb
           sudo updatedb
           sudo locate grafana
           sudo cat /etc/grafana/grafana.ini

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -191,7 +191,9 @@ jobs:
             - yarn-packages-{{ .Environment.CACHE_VERSION }}-{{ checksum "yarn.lock" }}
       - run:
           name: "Publish Release on GitHub"
-          command: npx grafana-toolkit plugin:github-publish
+          command: |
+            yarn install --frozen-lockfile
+            npx grafana-toolkit plugin:github-publish
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,6 +21,8 @@ jobs:
       - run:
           name: Install dependencies
           command: |
+            # Clean the yarn cache first on each run to ensure dependencies are correct.
+            yarn cache clean
             yarn install --frozen-lockfile
       - run:
           name: Build and test frontend
@@ -127,14 +129,10 @@ jobs:
     - run:
         name: Setup Grafana (local install)
         command: |
-          wget https://dl.grafana.com/oss/release/grafana_6.6.1_amd64.deb
-          sudo apt-get install -y adduser libfontconfig1
-          sudo dpkg -i grafana_6.6.1_amd64.deb
-          sudo apt-get install locate
+          sudo dpkg -i /usr/local/grafana/grafana_6.6.3_amd64.deb
           sudo updatedb
           sudo locate grafana
           sudo cat /etc/grafana/grafana.ini
-          sudo echo ------------------------
           sudo cp ci/grafana-test-env/custom.ini /usr/share/grafana/conf/custom.ini
           sudo cp ci/grafana-test-env/custom.ini /etc/grafana/grafana.ini
           sudo service grafana-server start

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ aliases:
 
 defaults: &defaults
   docker:
-    - image: srclosson/integrations-ci-build:latest
+    - image: srclosson/grafana-plugin-ci:latest
 
 jobs:
   build_plugin:
@@ -21,8 +21,7 @@ jobs:
       - run:
           name: Install dependencies
           command: |
-            # Clean the yarn cache first on each run to ensure dependencies are correct.
-            yarn cache clean && yarn install --frozen-lockfile
+            yarn install --frozen-lockfile
       - run:
           name: Build and test frontend
           command:  |
@@ -55,7 +54,7 @@ jobs:
       - run:
           name: Install dependencies
           command: |
-            yarn cache clean && yarn install --frozen-lockfile
+            yarn install --frozen-lockfile
       - run:
           name: Move results to ci folder
           command:  |
@@ -78,7 +77,7 @@ jobs:
     - run:
         name: Install dependencies
         command: |
-          yarn cache clean && yarn install --frozen-lockfile
+          yarn install --frozen-lockfile
     - run:
         name: Build Docs
         command: |
@@ -130,7 +129,6 @@ jobs:
           sudo dpkg -i /usr/local/grafana/deb/grafana_6.6.2_amd64.deb
           sudo updatedb
           sudo locate grafana
-          sudo cat /etc/grafana/grafana.ini
           sudo cp ci/grafana-test-env/custom.ini /usr/share/grafana/conf/custom.ini
           sudo cp ci/grafana-test-env/custom.ini /etc/grafana/grafana.ini
           sudo service grafana-server start

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,8 +22,7 @@ jobs:
           name: Install dependencies
           command: |
             # Clean the yarn cache first on each run to ensure dependencies are correct.
-            yarn cache clean
-            yarn install --frozen-lockfile
+            yarn cache clean && yarn install --frozen-lockfile
       - run:
           name: Build and test frontend
           command:  |
@@ -56,7 +55,7 @@ jobs:
       - run:
           name: Install dependencies
           command: |
-            yarn install --frozen-lockfile
+            yarn cache clean && yarn install --frozen-lockfile
       - run:
           name: Move results to ci folder
           command:  |
@@ -79,7 +78,7 @@ jobs:
     - run:
         name: Install dependencies
         command: |
-          yarn install --frozen-lockfile
+          yarn cache clean && yarn install --frozen-lockfile
     - run:
         name: Build Docs
         command: |
@@ -129,7 +128,7 @@ jobs:
     - run:
         name: Setup Grafana (local install)
         command: |
-          sudo dpkg -i /usr/local/grafana/grafana_6.6.2_amd64.deb
+          sudo dpkg -i /usr/local/grafana/deb/grafana_6.6.2_amd64.deb
           sudo updatedb
           sudo locate grafana
           sudo cat /etc/grafana/grafana.ini


### PR DESCRIPTION
Why? Because the wrong version of toolkit is being used that does not have the proper version of grafana toolkit. Bust cache.