### PR TITLE
Chore: change plugin id to include "grafana"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## v0.9.0
+
+- Official Release
+
 ## v0.1.0
 
-- Initial Release
+- Initial Release (preview)

--- a/README.md
+++ b/README.md
@@ -14,13 +14,13 @@ You need to install the following first:
 - [Yarn](https://yarnpkg.com/)
 - [Docker Compose](https://docs.docker.com/compose/)
 
-```
+```BASH
 mage watch
 ```
 
 In another terminal
 
-```
+```BASH
 docker-compose up
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "google-sheets-datasource",
-  "version": "0.9.0-dev",
+  "name": "grafana-google-sheets-datasource",
+  "version": "0.9.0",
   "description": "Load data from google sheets in grafana",
   "scripts": {
     "build": "grafana-toolkit plugin:build",

--- a/src/plugin.json
+++ b/src/plugin.json
@@ -1,7 +1,7 @@
 {
   "type": "datasource",
   "name": "Google Sheets",
-  "id": "grafana-google-sheets-datasource",
+  "id": "grafana-googlesheets-datasource",
   "backend": true,
   "executable": "gfx_sheets",
   "metrics": true,

--- a/src/plugin.json
+++ b/src/plugin.json
@@ -1,7 +1,7 @@
 {
   "type": "datasource",
   "name": "Google Sheets",
-  "id": "google-sheets-datasource",
+  "id": "grafana-google-sheets-datasource",
   "backend": true,
   "executable": "gfx_sheets",
   "metrics": true,
@@ -12,7 +12,9 @@
       "name": "Grafana Labs",
       "url": "https://grafana.com"
     },
-    "keywords": [],
+    "keywords": [
+      "google", "sheets", "spreadsheets", "excel"
+    ],
     "logos": {
       "small": "img/sheets.svg",
       "large": "img/sheets.svg"


### PR DESCRIPTION
Fixes #2

The plugin ID needs to start with the org name... unless it is enterprise

The "report" task in CI will fail since it is trying to publish to an unknown plugin ID