### PR TITLE
Fixes broken images on grafana.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 Visualize your Google Spreadsheets with Grafana
 
-![Visualize temperature date in Grafana Google Spreadsheets data source](https://github.com/grafana/google-sheets-datasource/blob/master/src/docs/img/dashboard.png)
+![Visualize temperature date in Grafana Google Spreadsheets data source](https://raw.githubusercontent.com/grafana/google-sheets-datasource/master/src/docs/img/dashboard.png)
 
-![Average temperatures in Google Sheets](https://github.com/grafana/google-sheets-datasource/blob/master/src/docs/img/spreadsheet.png)
+![Average temperatures in Google Sheets](https://raw.githubusercontent.com/grafana/google-sheets-datasource/master/src/docs/img/spreadsheet.png)
 
 ## Documentation
 


### PR DESCRIPTION
The images on Grafana.com and on the plugins page in Grafana are broken because the links don't point to the raw images.

Fixes this:

![image](https://user-images.githubusercontent.com/434655/78171351-9723c480-7454-11ea-993a-91dd8f635dfb.png)
