### PR TITLE
Chore: Pin to Node 12 via Volta

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,5 +23,8 @@
   },
   "dependencies": {
     "react-dropzone": "^10.2.1"
+  },
+  "volta": {
+    "node": "12.16.3"
   }
 }


### PR DESCRIPTION
Use [Volta](https://volta.sh/) Node version manager (a more modern and intelligent alternative than nvm) to pin Node to v12. We've already added the same metadata to Grafana's package.json :)