### PR TITLE
Possible v0.10.0 Release Candidate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## v0.9.0
+
+- Official Release
+
 ## v0.1.0
 
-- Initial Release
+- Initial Release (preview)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## v0.10.0
+
+- Unofficial Release with templating support
+
 ## v0.9.0
 
 - Official Release

--- a/README.md
+++ b/README.md
@@ -18,13 +18,13 @@ You need to install the following first:
 - [Yarn](https://yarnpkg.com/)
 - [Docker Compose](https://docs.docker.com/compose/)
 
-```
+```BASH
 mage watch
 ```
 
 In another terminal
 
-```
+```BASH
 docker-compose up
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grafana-google-sheets-datasource",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "Load data from google sheets in grafana",
   "scripts": {
     "build": "grafana-toolkit plugin:build",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "google-sheets-datasource",
-  "version": "0.9.0-dev",
+  "name": "grafana-google-sheets-datasource",
+  "version": "0.9.0",
   "description": "Load data from google sheets in grafana",
   "scripts": {
     "build": "grafana-toolkit plugin:build",

--- a/src/DataSource.ts
+++ b/src/DataSource.ts
@@ -1,11 +1,21 @@
 import { DataSourceInstanceSettings, SelectableValue } from '@grafana/data';
-import { DataSourceWithBackend } from '@grafana/runtime';
+import { DataSourceWithBackend, getDataSourceSrv } from '@grafana/runtime';
 
 import { SheetsQuery, SheetsSourceOptions } from './types';
 
 export class DataSource extends DataSourceWithBackend<SheetsQuery, SheetsSourceOptions> {
   constructor(instanceSettings: DataSourceInstanceSettings<SheetsSourceOptions>) {
     super(instanceSettings);
+  }
+
+  // Support template variables for spreadsheet and range
+  applyTemplateVariables(query: SheetsQuery) {
+    let templateSrv = (getDataSourceSrv() as any).templateSrv;
+    return {
+      ...query,
+      spreadsheet: templateSrv.replace(query.spreadsheet),
+      range: templateSrv.replace(query.range),
+    };
   }
 
   async getSpreadSheets(): Promise<Array<SelectableValue<string>>> {

--- a/src/plugin.json
+++ b/src/plugin.json
@@ -1,7 +1,7 @@
 {
   "type": "datasource",
   "name": "Google Sheets",
-  "id": "google-sheets-datasource",
+  "id": "grafana-googlesheets-datasource",
   "backend": true,
   "executable": "gfx_sheets",
   "metrics": true,
@@ -12,7 +12,9 @@
       "name": "Grafana Labs",
       "url": "https://grafana.com"
     },
-    "keywords": [],
+    "keywords": [
+      "google", "sheets", "spreadsheets", "excel"
+    ],
     "logos": {
       "small": "img/sheets.svg",
       "large": "img/sheets.svg"


### PR DESCRIPTION
Hi there,

Recently I discovered the v0.9.0 release (and only Grafana v6.X compatible version) of this plugin was missing the same templating features as the v1.0 release. This PR sees a minor modification to the frontend to provide the same variable templating functionality as the v1.0 release.

I am not really certain of which branch to aim this at but this diff looks accurate. If PR's for pre v1.0 are not being accepted please just close (I figured I try my luck).