### PR TITLE
doc: Try to clarify where to look for further instructions

### DIFF
--- a/src/docs/configuration.md
+++ b/src/docs/configuration.md
@@ -18,7 +18,7 @@ The project that the service account is associated with needs to be granted acce
 
 The Google Sheets data source uses the scope `https://www.googleapis.com/auth/spreadsheets.readonly` to get read-only access to spreadsheets. It also uses the scope `https://www.googleapis.com/auth/drive.metadata.readonly` to list all spreadsheets that the service account has access to in Google Drive.
 
-To create a service account, generate a Google JWT file and enable the APIs, follow the steps in the Google Sheets data source configuration page.
+To create a service account, generate a Google JWT file and enable the APIs. For more detailed instructions, refer to the steps documented for the Google Sheets data source in the "Add a data source" page in Grafana.  
 
 ### Sharing
 


### PR DESCRIPTION
This sentence is still a little unclear and wordy. The existing sentence confused me because of the similarity between the document title and the referenced "Google Sheets data source configuration page"