### PR TITLE
(config) Change links to open in a new tab

### DIFF
--- a/src/components/ConfigEditor.tsx
+++ b/src/components/ConfigEditor.tsx
@@ -88,7 +88,7 @@ export class ConfigEditor extends PureComponent<Props> {
               <h4>Generate a JWT file</h4>
               <ol style={{ listStylePosition: 'inside' }}>
                 <li>
-                  Open the <a href="https://console.developers.google.com/apis/credentials" target="_blank">Credentials</a> page in the
+                  Open the <a href="https://console.developers.google.com/apis/credentials" target="_blank" rel="noreferrer noopener">Credentials</a> page in the
                   Google API Console.
                 </li>
                 <li>
@@ -109,14 +109,14 @@ export class ConfigEditor extends PureComponent<Props> {
                 </li>
                 <li>
                   Open the{' '}
-                  <a href="https://console.cloud.google.com/apis/library/sheets.googleapis.com?q=sheet" target="_blank">
+                  <a href="https://console.cloud.google.com/apis/library/sheets.googleapis.com?q=sheet" target="_blank" rel="noreferrer noopener">
                     Google Sheets
                   </a>{' '}
                   in API Library and enable access for your account
                 </li>
                 <li>
                   Open the{' '}
-                  <a href="https://console.cloud.google.com/apis/library/drive.googleapis.com?q=drive" target="_blank">Google Drive</a>{' '}
+                  <a href="https://console.cloud.google.com/apis/library/drive.googleapis.com?q=drive" target="_blank" rel="noreferrer noopener">Google Drive</a>{' '}
                   in API Library and enable access for your account. Access to the Google Drive API is used to list all
                   spreadsheets that you have access to.
                 </li>
@@ -131,7 +131,7 @@ export class ConfigEditor extends PureComponent<Props> {
               <h4>Generate an API key</h4>
               <ol style={{ listStylePosition: 'inside' }}>
                 <li>
-                  Open the <a href="https://console.developers.google.com/apis/credentials" target="_blank">Credentials page</a> in the
+                  Open the <a href="https://console.developers.google.com/apis/credentials" target="_blank" rel="noreferrer noopener">Credentials page</a> in the
                   Google API Console.
                 </li>
                 <li>

--- a/src/components/ConfigEditor.tsx
+++ b/src/components/ConfigEditor.tsx
@@ -88,8 +88,15 @@ export class ConfigEditor extends PureComponent<Props> {
               <h4>Generate a JWT file</h4>
               <ol style={{ listStylePosition: 'inside' }}>
                 <li>
-                  Open the <a href="https://console.developers.google.com/apis/credentials" target="_blank" rel="noreferrer noopener">Credentials</a> page in the
-                  Google API Console.
+                  Open the{' '}
+                  <a
+                    href="https://console.developers.google.com/apis/credentials"
+                    target="_blank"
+                    rel="noreferrer noopener"
+                  >
+                    Credentials
+                  </a>{' '}
+                  page in the Google API Console.
                 </li>
                 <li>
                   Click <strong>Create Credentials</strong> then click <strong>Service account</strong>.
@@ -109,14 +116,24 @@ export class ConfigEditor extends PureComponent<Props> {
                 </li>
                 <li>
                   Open the{' '}
-                  <a href="https://console.cloud.google.com/apis/library/sheets.googleapis.com?q=sheet" target="_blank" rel="noreferrer noopener">
+                  <a
+                    href="https://console.cloud.google.com/apis/library/sheets.googleapis.com?q=sheet"
+                    target="_blank"
+                    rel="noreferrer noopener"
+                  >
                     Google Sheets
                   </a>{' '}
                   in API Library and enable access for your account
                 </li>
                 <li>
                   Open the{' '}
-                  <a href="https://console.cloud.google.com/apis/library/drive.googleapis.com?q=drive" target="_blank" rel="noreferrer noopener">Google Drive</a>{' '}
+                  <a
+                    href="https://console.cloud.google.com/apis/library/drive.googleapis.com?q=drive"
+                    target="_blank"
+                    rel="noreferrer noopener"
+                  >
+                    Google Drive
+                  </a>{' '}
                   in API Library and enable access for your account. Access to the Google Drive API is used to list all
                   spreadsheets that you have access to.
                 </li>
@@ -131,8 +148,15 @@ export class ConfigEditor extends PureComponent<Props> {
               <h4>Generate an API key</h4>
               <ol style={{ listStylePosition: 'inside' }}>
                 <li>
-                  Open the <a href="https://console.developers.google.com/apis/credentials" target="_blank" rel="noreferrer noopener">Credentials page</a> in the
-                  Google API Console.
+                  Open the{' '}
+                  <a
+                    href="https://console.developers.google.com/apis/credentials"
+                    target="_blank"
+                    rel="noreferrer noopener"
+                  >
+                    Credentials page
+                  </a>{' '}
+                  in the Google API Console.
                 </li>
                 <li>
                   Click <strong>Create Credentials</strong> and then click <strong>API key</strong>.

--- a/src/components/ConfigEditor.tsx
+++ b/src/components/ConfigEditor.tsx
@@ -88,7 +88,7 @@ export class ConfigEditor extends PureComponent<Props> {
               <h4>Generate a JWT file</h4>
               <ol style={{ listStylePosition: 'inside' }}>
                 <li>
-                  Open the <a href="https://console.developers.google.com/apis/credentials">Credentials</a> page in the
+                  Open the <a href="https://console.developers.google.com/apis/credentials" target="_blank">Credentials</a> page in the
                   Google API Console.
                 </li>
                 <li>
@@ -109,14 +109,14 @@ export class ConfigEditor extends PureComponent<Props> {
                 </li>
                 <li>
                   Open the{' '}
-                  <a href="https://console.cloud.google.com/apis/library/sheets.googleapis.com?q=sheet">
+                  <a href="https://console.cloud.google.com/apis/library/sheets.googleapis.com?q=sheet" target="_blank">
                     Google Sheets
                   </a>{' '}
                   in API Library and enable access for your account
                 </li>
                 <li>
                   Open the{' '}
-                  <a href="https://console.cloud.google.com/apis/library/drive.googleapis.com?q=drive">Google Drive</a>{' '}
+                  <a href="https://console.cloud.google.com/apis/library/drive.googleapis.com?q=drive" target="_blank">Google Drive</a>{' '}
                   in API Library and enable access for your account. Access to the Google Drive API is used to list all
                   spreadsheets that you have access to.
                 </li>
@@ -131,7 +131,7 @@ export class ConfigEditor extends PureComponent<Props> {
               <h4>Generate an API key</h4>
               <ol style={{ listStylePosition: 'inside' }}>
                 <li>
-                  Open the <a href="https://console.developers.google.com/apis/credentials">Credentials page</a> in the
+                  Open the <a href="https://console.developers.google.com/apis/credentials" target="_blank">Credentials page</a> in the
                   Google API Console.
                 </li>
                 <li>


### PR DESCRIPTION
Super minor, but when I went through and was configuring the settings for the first time I assumed external links would open in a new tab but they didn't and I thought I'd drop a PR to add in the `target='_blank'` to see what y'all thought.