### PR TITLE
Fix panic when referencing a range with no data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to this project will be documented in this file.
 
+## v1.1.6
+- Fix: Don't panic when the user selects a range of empty cells.
+
 ## v1.1.5
 
 - **Chore**: Update to Golang 1.19 #160

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grafana-google-sheets-datasource",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "description": "Load data from google sheets in grafana",
   "scripts": {
     "build": "rm -rf node_modules/@grafana/data/node_modules; grafana-toolkit plugin:build && mage",

--- a/pkg/googlesheets/googlesheets.go
+++ b/pkg/googlesheets/googlesheets.go
@@ -255,6 +255,9 @@ func getUniqueColumnName(formattedName string, columnIndex int, columns map[stri
 func getColumnDefinitions(rows []*sheets.RowData) ([]*ColumnDefinition, int) {
 	columns := []*ColumnDefinition{}
 	columnMap := map[string]bool{}
+	if len(rows) < 1 {
+		return columns, 0
+	}
 	headerRow := rows[0].Values
 
 	start := 0


### PR DESCRIPTION
When trying to use a range like `Sheet1!A5` and A5 is empty `rows` will be empty. Let's return an empty column definition instead of panicking because `rows[0]`

Fixes: #163