### PR TITLE
Add sharing service account email to JWT config instructions

### DIFF
--- a/src/components/ConfigEditor.tsx
+++ b/src/components/ConfigEditor.tsx
@@ -138,6 +138,10 @@ export class ConfigEditor extends PureComponent<Props> {
                   spreadsheets that you have access to.
                 </li>
                 <li>
+                  Share the files/folders you want to access with the service account&apos;s email address. The email is
+                  specified as <code>client_email</code> in the Google JWT File.
+                </li>
+                <li>
                   Drag the file to the dotted zone above. Then click <code>Save & Test</code>. The file contents will be
                   encrypted and saved in the Grafana database.
                 </li>

--- a/src/components/ConfigEditor.tsx
+++ b/src/components/ConfigEditor.tsx
@@ -138,8 +138,8 @@ export class ConfigEditor extends PureComponent<Props> {
                   spreadsheets that you have access to.
                 </li>
                 <li>
-                  Share the files/folders you want to access with the service account&apos;s email address. The email is
-                  specified as <code>client_email</code> in the Google JWT File.
+                  Share any private files/folders you want to access with the service account&apos;s email address. The
+                  email is specified as <code>client_email</code> in the Google JWT File.
                 </li>
                 <li>
                   Drag the file to the dotted zone above. Then click <code>Save & Test</code>. The file contents will be


### PR DESCRIPTION
Mentions the step of sharing the service account email with the desired files to hopefully make getting started easier. Considering that the JWT instructions walk you through creating the account, it seems misleading not to mention this.

fixes #181