### PR TITLE
Fix the backend executable name for create-plugin

### DIFF
--- a/src/plugin.json
+++ b/src/plugin.json
@@ -6,7 +6,7 @@
   "id": "grafana-googlesheets-datasource",
 
   "backend": true,
-  "executable": "gfx_sheets",
+  "executable": "gpx_sheets",
   "metrics": true,
   "annotations": true,
 


### PR DESCRIPTION
Currently, using yarn removes all the built backend files from `dist`, which is both inconvenient and confusing for development. This is because the `webpack.config.ts` from `create-plugin` expects backend executables to match the `/gpx_.*/` regex. This changes the executable name to match what is expected, so the files aren't removed.

fixes: #179