### PR TITLE
add codeowners file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @grafana/oss-big-tent


### PR DESCRIPTION
the plugin is going to be maintained by the oss big tent squad in the future.

(part of https://github.com/grafana/grafana/issues/72755)