### PR TITLE
POC/k8s: use forked kube-openapi 

### DIFF
--- a/cspell.config.json
+++ b/cspell.config.json
@@ -1,6 +1,11 @@
 {
-  "ignorePaths": ["node_modules/**", "pkg/googlesheets/testdata", "dist/**"],
+  "ignorePaths": [
+    "node_modules/**",
+    "pkg/googlesheets/testdata",
+    "dist/**"
+  ],
   "words": [
+    "APIV",
     "araddon",
     "dataproxy",
     "datasource",
@@ -11,9 +16,9 @@
     "httpadapter",
     "httpclient",
     "instancemgmt",
+    "Middlewares",
     "patrickmn",
     "Sdump",
-    "Middlewares",
     "stackdriver",
     "stretchr",
     "testdata",

--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,8 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.3
 )
 
-replace k8s.io/kube-openapi v0.0.0-20230501164219-8b0f38b5fd1f => github.com/ryantxu/kube-openapi v0.0.0-20230824043724-ccc3f70d4321
+// Includes https://github.com/kubernetes/kube-openapi/pull/420 (but before gnostic change)
+replace k8s.io/kube-openapi v0.0.0-20230501164219-8b0f38b5fd1f => github.com/ryantxu/kube-openapi v0.0.0-20230824154605-fe0f3703fd8d
 
 require (
 	cloud.google.com/go/compute v1.18.0 // indirect
@@ -63,7 +64,6 @@ require (
 	github.com/google/cel-go v0.12.6 // indirect
 	github.com/google/flatbuffers v2.0.0+incompatible // indirect
 	github.com/google/gnostic v0.5.7-v3refs // indirect
-	github.com/google/gnostic-models v0.6.8 // indirect
 	github.com/google/go-cmp v0.5.9 // indirect
 	github.com/google/gofuzz v1.1.0 // indirect
 	github.com/google/uuid v1.3.0 // indirect
@@ -89,6 +89,7 @@ require (
 	github.com/mattn/go-runewidth v0.0.10 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.4 // indirect
 	github.com/mitchellh/go-testing-interface v1.0.0 // indirect
+	github.com/mitchellh/mapstructure v1.4.1 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826 // indirect

--- a/go.mod
+++ b/go.mod
@@ -7,12 +7,14 @@ replace github.com/grafana/kindsys => ../../kindsys
 require (
 	github.com/araddon/dateparse v0.0.0-20210429162001-6b43995a97de
 	github.com/davecgh/go-spew v1.1.1
+	github.com/gorilla/mux v1.8.0
 	github.com/grafana/grafana-google-sdk-go v0.2.1
 	github.com/grafana/grafana-plugin-sdk-go v0.149.1
 	github.com/grafana/kindsys v0.0.0-20230802133549-74f2bc812610
 	github.com/patrickmn/go-cache v2.1.0+incompatible
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.8.3
+	github.com/vectordotdev/go-datemath v0.1.1-0.20220323213446-f3954d0b18ae
 	golang.org/x/oauth2 v0.7.0
 	google.golang.org/api v0.110.0
 	k8s.io/apimachinery v0.27.4
@@ -24,9 +26,7 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.3
 )
 
-require github.com/vectordotdev/go-datemath v0.1.1-0.20220323213446-f3954d0b18ae
-
-require github.com/gorilla/mux v1.8.0
+replace k8s.io/kube-openapi v0.0.0-20230501164219-8b0f38b5fd1f => github.com/ryantxu/kube-openapi v0.0.0-20230824043724-ccc3f70d4321
 
 require (
 	cloud.google.com/go/compute v1.18.0 // indirect
@@ -63,6 +63,7 @@ require (
 	github.com/google/cel-go v0.12.6 // indirect
 	github.com/google/flatbuffers v2.0.0+incompatible // indirect
 	github.com/google/gnostic v0.5.7-v3refs // indirect
+	github.com/google/gnostic-models v0.6.8 // indirect
 	github.com/google/go-cmp v0.5.9 // indirect
 	github.com/google/gofuzz v1.1.0 // indirect
 	github.com/google/uuid v1.3.0 // indirect
@@ -88,7 +89,6 @@ require (
 	github.com/mattn/go-runewidth v0.0.10 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.4 // indirect
 	github.com/mitchellh/go-testing-interface v1.0.0 // indirect
-	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826 // indirect

--- a/go.sum
+++ b/go.sum
@@ -204,6 +204,8 @@ github.com/google/flatbuffers v2.0.0+incompatible h1:dicJ2oXwypfwUGnB2/TYWYEKiuk
 github.com/google/flatbuffers v2.0.0+incompatible/go.mod h1:1AeVuKshWv4vARoZatz6mlQ0JxURH0Kv5+zNeJKJCa8=
 github.com/google/gnostic v0.5.7-v3refs h1:FhTMOKj2VhjpouxvWJAV1TL304uMlb9zcDqkl6cEI54=
 github.com/google/gnostic v0.5.7-v3refs/go.mod h1:73MKFl6jIHelAJNaBGFzt3SPtZULs9dYrGFt8OiIsHQ=
+github.com/google/gnostic-models v0.6.8 h1:yo/ABAfM5IMRsS1VnXjTBvUb61tFIHozhlYvRgGre9I=
+github.com/google/gnostic-models v0.6.8/go.mod h1:5n7qKqH0f5wFt+aWF8CW6pZLLNOfYuF5OpfBSENuI8U=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
@@ -327,8 +329,6 @@ github.com/matttproud/golang_protobuf_extensions v1.0.4/go.mod h1:BSXmuO+STAnVfr
 github.com/mitchellh/go-testing-interface v0.0.0-20171004221916-a61a99592b77/go.mod h1:kRemZodwjscx+RGhAo8eIhFbs2+BFgRtFPeD/KE+zxI=
 github.com/mitchellh/go-testing-interface v1.0.0 h1:fzU/JVNcaqHQEcVFAKeR41fkiLdIPrefOvVG1VZ96U0=
 github.com/mitchellh/go-testing-interface v1.0.0/go.mod h1:kRemZodwjscx+RGhAo8eIhFbs2+BFgRtFPeD/KE+zxI=
-github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyuac5Z2hdY=
-github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/mitchellh/reflectwalk v1.0.2 h1:G2LzWKi524PWgd3mLHV8Y5k7s6XUvT0Gef6zxSIeXaQ=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
@@ -379,6 +379,8 @@ github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQD
 github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/ruudk/golang-pdf417 v0.0.0-20181029194003-1af4ab5afa58/go.mod h1:6lfFZQK844Gfx8o5WFuvpxWRwnSoipWe/p622j1v06w=
+github.com/ryantxu/kube-openapi v0.0.0-20230824043724-ccc3f70d4321 h1:MP1ceoAm2ZlVYgLauXzWWmt5dP8yb1YPIYUs4+zOgvo=
+github.com/ryantxu/kube-openapi v0.0.0-20230824043724-ccc3f70d4321/go.mod h1:wZK2AVp1uHCp4VamDVgBP2COHZjqD1T68Rf0CM3YjSM=
 github.com/scylladb/termtables v0.0.0-20191203121021-c4c0b6d42ff4/go.mod h1:C1a7PQSMz9NShzorzCiG2fk9+xuCgLkPeCvMHYR2OWg=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
@@ -849,8 +851,6 @@ k8s.io/klog/v2 v2.90.1 h1:m4bYOKall2MmOiRaR1J+We67Do7vm9KiQVlT96lnHUw=
 k8s.io/klog/v2 v2.90.1/go.mod h1:y1WjHnz7Dj687irZUWR/WLkLc5N1YHtjLdmgWjndZn0=
 k8s.io/kms v0.27.4 h1:FeT17HfqxZMP7dTq3Gpa9dG05iP3J3wgGtqGh1SUoN0=
 k8s.io/kms v0.27.4/go.mod h1:0BY6tkfa+zOP85u8yE7iNNf1Yx7rEZnRQSWLEbsSk+w=
-k8s.io/kube-openapi v0.0.0-20230501164219-8b0f38b5fd1f h1:2kWPakN3i/k81b0gvD5C5FJ2kxm1WrQFanWchyKuqGg=
-k8s.io/kube-openapi v0.0.0-20230501164219-8b0f38b5fd1f/go.mod h1:byini6yhqGC14c3ebc/QwanvYwhuMWF6yz2F8uwW8eg=
 k8s.io/utils v0.0.0-20230406110748-d93618cff8a2 h1:qY1Ad8PODbnymg2pRbkyMT/ylpTrCM8P2RJ0yroCyIk=
 k8s.io/utils v0.0.0-20230406110748-d93618cff8a2/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=

--- a/go.sum
+++ b/go.sum
@@ -204,8 +204,6 @@ github.com/google/flatbuffers v2.0.0+incompatible h1:dicJ2oXwypfwUGnB2/TYWYEKiuk
 github.com/google/flatbuffers v2.0.0+incompatible/go.mod h1:1AeVuKshWv4vARoZatz6mlQ0JxURH0Kv5+zNeJKJCa8=
 github.com/google/gnostic v0.5.7-v3refs h1:FhTMOKj2VhjpouxvWJAV1TL304uMlb9zcDqkl6cEI54=
 github.com/google/gnostic v0.5.7-v3refs/go.mod h1:73MKFl6jIHelAJNaBGFzt3SPtZULs9dYrGFt8OiIsHQ=
-github.com/google/gnostic-models v0.6.8 h1:yo/ABAfM5IMRsS1VnXjTBvUb61tFIHozhlYvRgGre9I=
-github.com/google/gnostic-models v0.6.8/go.mod h1:5n7qKqH0f5wFt+aWF8CW6pZLLNOfYuF5OpfBSENuI8U=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
@@ -329,6 +327,8 @@ github.com/matttproud/golang_protobuf_extensions v1.0.4/go.mod h1:BSXmuO+STAnVfr
 github.com/mitchellh/go-testing-interface v0.0.0-20171004221916-a61a99592b77/go.mod h1:kRemZodwjscx+RGhAo8eIhFbs2+BFgRtFPeD/KE+zxI=
 github.com/mitchellh/go-testing-interface v1.0.0 h1:fzU/JVNcaqHQEcVFAKeR41fkiLdIPrefOvVG1VZ96U0=
 github.com/mitchellh/go-testing-interface v1.0.0/go.mod h1:kRemZodwjscx+RGhAo8eIhFbs2+BFgRtFPeD/KE+zxI=
+github.com/mitchellh/mapstructure v1.4.1 h1:CpVNEelQCZBooIPDn+AR3NpivK/TIKU8bDxdASFVQag=
+github.com/mitchellh/mapstructure v1.4.1/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/mitchellh/reflectwalk v1.0.2 h1:G2LzWKi524PWgd3mLHV8Y5k7s6XUvT0Gef6zxSIeXaQ=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
@@ -379,8 +379,8 @@ github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQD
 github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/ruudk/golang-pdf417 v0.0.0-20181029194003-1af4ab5afa58/go.mod h1:6lfFZQK844Gfx8o5WFuvpxWRwnSoipWe/p622j1v06w=
-github.com/ryantxu/kube-openapi v0.0.0-20230824043724-ccc3f70d4321 h1:MP1ceoAm2ZlVYgLauXzWWmt5dP8yb1YPIYUs4+zOgvo=
-github.com/ryantxu/kube-openapi v0.0.0-20230824043724-ccc3f70d4321/go.mod h1:wZK2AVp1uHCp4VamDVgBP2COHZjqD1T68Rf0CM3YjSM=
+github.com/ryantxu/kube-openapi v0.0.0-20230824154605-fe0f3703fd8d h1:/aSzsDXklM83yExguLXwl/nMrW8/7Lgefg2q632YynY=
+github.com/ryantxu/kube-openapi v0.0.0-20230824154605-fe0f3703fd8d/go.mod h1:byini6yhqGC14c3ebc/QwanvYwhuMWF6yz2F8uwW8eg=
 github.com/scylladb/termtables v0.0.0-20191203121021-c4c0b6d42ff4/go.mod h1:C1a7PQSMz9NShzorzCiG2fk9+xuCgLkPeCvMHYR2OWg=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=

--- a/pkg/ext/options.go
+++ b/pkg/ext/options.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"time"
 
+	"k8s.io/kube-openapi/pkg/spec3"
 	"k8s.io/kube-openapi/pkg/validation/spec"
 
 	v1 "github.com/grafana/google-sheets-datasource/pkg/apis/googlesheets/v1"
@@ -180,9 +181,14 @@ func (o *PluginAggregatedServerOptions) Config() (*Config, error) {
 		}
 		return s, nil
 	}
-	// cry face!!! the hook is not called here!!!
-	// serverConfig.OpenAPIV3Config = genericapiserver.DefaultOpenAPIV3Config(openapi.GetOpenAPIDefinitionsWithoutDisabledFeatures(generatedopenapi.GetOpenAPIDefinitions), openapinamer.NewDefinitionNamer(Scheme, scheme.Scheme))
-	// serverConfig.OpenAPIV3Config.PostProcessSpec = serverConfig.OpenAPIConfig.PostProcessSpec
+	serverConfig.OpenAPIV3Config = genericapiserver.DefaultOpenAPIV3Config(openapi.GetOpenAPIDefinitionsWithoutDisabledFeatures(generatedopenapi.GetOpenAPIDefinitions), openapinamer.NewDefinitionNamer(Scheme, scheme.Scheme))
+	serverConfig.OpenAPIV3Config.PostProcessSpec3 = func(s *spec3.OpenAPI) (*spec3.OpenAPI, error) {
+		s.Info.Title = "POST PROCESSED V3!!!"
+		s.Info.VendorExtensible = spec.VendorExtensible{
+			Extensions: map[string]any{"hello": "world(3)"},
+		}
+		return s, nil
+	}
 	serverConfig.SkipOpenAPIInstallation = false
 	serverConfig.SharedInformerFactory = clientGoInformers.NewSharedInformerFactory(fake.NewSimpleClientset(), 10*time.Minute)
 	serverConfig.ClientConfig = &rest.Config{}

--- a/pkg/ext/options.go
+++ b/pkg/ext/options.go
@@ -181,11 +181,81 @@ func (o *PluginAggregatedServerOptions) Config() (*Config, error) {
 		}
 		return s, nil
 	}
+
 	serverConfig.OpenAPIV3Config = genericapiserver.DefaultOpenAPIV3Config(openapi.GetOpenAPIDefinitionsWithoutDisabledFeatures(generatedopenapi.GetOpenAPIDefinitions), openapinamer.NewDefinitionNamer(Scheme, scheme.Scheme))
 	serverConfig.OpenAPIV3Config.PostProcessSpec3 = func(s *spec3.OpenAPI) (*spec3.OpenAPI, error) {
-		s.Info.Title = "POST PROCESSED V3!!!"
-		s.Info.VendorExtensible = spec.VendorExtensible{
-			Extensions: map[string]any{"hello": "world(3)"},
+		if s.Paths != nil && s.Paths.Paths["/apis/googlesheets.ext.grafana.com/v1/"] != nil {
+			copy := *s // will copy the rest of the properties
+			copy.Info.Title = "Google sheets plugin"
+
+			ttt := []string{"builtin k8s"}
+			for _, p := range s.Paths.Paths {
+				if p.Get != nil {
+					p.Get.Tags = ttt
+				}
+				if p.Post != nil {
+					p.Post.Tags = ttt
+				}
+				if p.Patch != nil {
+					p.Patch.Tags = ttt
+				}
+				if p.Put != nil {
+					p.Put.Tags = ttt
+				}
+				if p.Delete != nil {
+					p.Delete.Tags = ttt
+				}
+			}
+
+			copy.Paths.Paths["/apis/googlesheets.ext.grafana.com/v1/anything"] = &spec3.Path{
+				PathProps: spec3.PathProps{
+					Summary: "the query method",
+					Get: &spec3.Operation{
+						OperationProps: spec3.OperationProps{
+							Description: "method at the rood plugin level",
+							Tags:        []string{"plugin level (no config)"},
+						},
+					},
+				},
+			}
+
+			copy.Paths.Paths["/apis/googlesheets.ext.grafana.com/v1/namespaces/{namespace}/anything"] = &spec3.Path{
+				PathProps: spec3.PathProps{
+					Summary: "the query method",
+					Get: &spec3.Operation{
+						OperationProps: spec3.OperationProps{
+							Description: "method at the org/tenant level",
+							Tags:        []string{"tenant level"},
+						},
+					},
+				},
+			}
+
+			copy.Paths.Paths["/apis/googlesheets.ext.grafana.com/v1/namespaces/{namespace}/datasources/{name}/query"] = &spec3.Path{
+				PathProps: spec3.PathProps{
+					Summary: "the query method",
+					Post: &spec3.Operation{
+						OperationProps: spec3.OperationProps{
+							Description: "the query method",
+							Tags:        []string{"datasource level"},
+						},
+					},
+				},
+			}
+
+			copy.Paths.Paths["/apis/googlesheets.ext.grafana.com/v1/namespaces/{namespace}/datasources/{name}/health"] = &spec3.Path{
+				PathProps: spec3.PathProps{
+					Summary: "healthcheck",
+					Get: &spec3.Operation{
+						OperationProps: spec3.OperationProps{
+							Description: "do healthcheck",
+							Tags:        []string{"datasource level"},
+						},
+					},
+				},
+			}
+
+			return &copy, nil
 		}
 		return s, nil
 	}

--- a/pkg/ext/runner.go
+++ b/pkg/ext/runner.go
@@ -1,6 +1,7 @@
 package ext
 
 import (
+	"fmt"
 	"net/http"
 	"path"
 
@@ -136,7 +137,9 @@ func (o PluginAggregatedServerOptions) Run(stopCh <-chan struct{}) error {
 		return nil
 	})
 
-	return server.GenericAPIServer.PrepareRun().Run(stopCh)
+	v := server.GenericAPIServer.PrepareRun()
+	fmt.Printf("RUN: %v\n", v)
+	return v.Run(stopCh)
 }
 
 func writeKubeConfiguration(restConfig *clientRest.Config) error {

--- a/pkg/ext/runner.go
+++ b/pkg/ext/runner.go
@@ -1,7 +1,6 @@
 package ext
 
 import (
-	"fmt"
 	"net/http"
 	"path"
 
@@ -137,9 +136,7 @@ func (o PluginAggregatedServerOptions) Run(stopCh <-chan struct{}) error {
 		return nil
 	})
 
-	v := server.GenericAPIServer.PrepareRun()
-	fmt.Printf("RUN: %v\n", v)
-	return v.Run(stopCh)
+	return server.GenericAPIServer.PrepareRun().Run(stopCh)
 }
 
 func writeKubeConfiguration(restConfig *clientRest.Config) error {


### PR DESCRIPTION
trying to use https://github.com/kubernetes/kube-openapi/pull/420 -- this now allows hardcoding additional paths into the final results:

<img width="1225" alt="image" src="https://github.com/grafana/google-sheets-datasource/assets/705951/fb1608c6-aab2-4f6b-bf1d-05d2d34c2e24">
