### PR TITLE
Fix: Do not mutate options object

### DIFF
--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -1,0 +1,58 @@
+import { GoogleSheetsAuth } from './types';
+import { getBackwardCompatibleOptions } from './utils';
+
+describe('getBackwardCompatibleOptions', () => {
+  it('should not mutate the option object', () => {
+    const options: any = Object.freeze({
+      jsonData: Object.freeze({
+        authenticationType: GoogleSheetsAuth.JWT,
+      }),
+      secureJsonFields: Object.freeze({}),
+    });
+    expect(getBackwardCompatibleOptions(options)).toEqual(options);
+  });
+
+  it('should set authenticationType to authType if authType is set', () => {
+    const options: any = {
+      jsonData: {
+        authType: GoogleSheetsAuth.API,
+      },
+      secureJsonFields: {},
+    };
+    const expectedOptions = {
+      jsonData: {
+        authenticationType: GoogleSheetsAuth.API,
+        authType: GoogleSheetsAuth.API,
+      },
+      secureJsonFields: {},
+    };
+    expect(getBackwardCompatibleOptions(options)).toEqual(expectedOptions);
+  });
+
+  it('should set JWT fields to "configured" if JWT is set in secureJsonFields', () => {
+    const options: any = {
+      jsonData: {
+        authenticationType: GoogleSheetsAuth.JWT,
+        clientEmail: '',
+        defaultProject: '',
+        tokenUri: '',
+      },
+      secureJsonFields: {
+        jwt: true,
+      },
+    };
+    const expectedOptions = {
+      jsonData: {
+        authenticationType: GoogleSheetsAuth.JWT,
+        clientEmail: 'configured',
+        defaultProject: 'configured',
+        tokenUri: 'configured',
+      },
+      secureJsonFields: {
+        jwt: true,
+        privateKey: true,
+      },
+    };
+    expect(getBackwardCompatibleOptions(options)).toEqual(expectedOptions);
+  });
+});

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -2,7 +2,11 @@ import { GoogleSheetsAuth } from './types';
 import { Props } from './components/ConfigEditor';
 
 export function getBackwardCompatibleOptions(options: Props['options']): Props['options'] {
-  const changedOptions = { ...options };
+  const changedOptions = {
+    ...options,
+    jsonData: { ...options.jsonData },
+    secureJsonFields: { ...options.secureJsonFields },
+  };
   // Make sure we support the old authType property
   changedOptions.jsonData.authenticationType = options.jsonData.authenticationType || options.jsonData.authType!;
 


### PR DESCRIPTION
This fixes an issue we see in cloud `Cannot assign to read only property 'authenticationType' of object '#'` by not mutating the jsonData object.