### PR TITLE
Don't track query requests on dashboard reload

### DIFF
--- a/src/DataSource.ts
+++ b/src/DataSource.ts
@@ -1,4 +1,5 @@
 import {
+  CoreApp,
   DataQueryRequest,
   DataQueryResponse,
   DataSourceInstanceSettings,
@@ -19,6 +20,10 @@ export class DataSource extends DataSourceWithBackend<SheetsQuery, DataSourceOpt
 
   query(request: DataQueryRequest<SheetsQuery>): Observable<DataQueryResponse> {
     request.targets.forEach((target) => {
+      if (request.app === CoreApp.Dashboard || request.app === CoreApp.PanelViewer) {
+        return;
+      }
+
       reportInteraction('grafana_google_sheets_query_executed', {
         app: request.app,
         useTimeFilter: target.useTimeFilter ?? false,

--- a/src/DataSource.ts
+++ b/src/DataSource.ts
@@ -1,5 +1,4 @@
 import {
-  CoreApp,
   DataQueryRequest,
   DataQueryResponse,
   DataSourceInstanceSettings,
@@ -7,9 +6,10 @@ import {
   SelectableValue,
 } from '@grafana/data';
 import { DataSourceOptions } from '@grafana/google-sdk';
-import { DataSourceWithBackend, getTemplateSrv, reportInteraction } from '@grafana/runtime';
+import { DataSourceWithBackend, getTemplateSrv } from '@grafana/runtime';
 import { SheetsQuery } from './types';
 import { Observable } from 'rxjs';
+import { trackRequest } from 'tracking';
 
 export class DataSource extends DataSourceWithBackend<SheetsQuery, DataSourceOptions> {
   authType: string;
@@ -19,18 +19,7 @@ export class DataSource extends DataSourceWithBackend<SheetsQuery, DataSourceOpt
   }
 
   query(request: DataQueryRequest<SheetsQuery>): Observable<DataQueryResponse> {
-    request.targets.forEach((target) => {
-      if (request.app === CoreApp.Dashboard || request.app === CoreApp.PanelViewer) {
-        return;
-      }
-
-      reportInteraction('grafana_google_sheets_query_executed', {
-        app: request.app,
-        useTimeFilter: target.useTimeFilter ?? false,
-        cacheDurationSeconds: target.cacheDurationSeconds ?? 0,
-      });
-    });
-
+    trackRequest(request);
     return super.query(request);
   }
 

--- a/src/tracking.ts
+++ b/src/tracking.ts
@@ -1,0 +1,17 @@
+import { CoreApp, DataQueryRequest } from '@grafana/data';
+import { reportInteraction } from '@grafana/runtime';
+import { SheetsQuery } from 'types';
+
+export const trackRequest = (request: DataQueryRequest<SheetsQuery>) => {
+  if (request.app === CoreApp.Dashboard || request.app === CoreApp.PanelViewer) {
+    return;
+  }
+
+  request.targets.forEach((target) => {
+    reportInteraction('grafana_google_sheets_query_executed', {
+      app: request.app,
+      useTimeFilter: target.useTimeFilter ?? false,
+      cacheDurationSeconds: target.cacheDurationSeconds ?? 0,
+    });
+  });
+};


### PR DESCRIPTION
currently we track all query requests, this PR excludes requests on dashboard reload which improves performance.