### PR TITLE
Configuration help: Add additional instruction to enable Google Sheet API

### DIFF
--- a/src/components/ConfigurationHelp.tsx
+++ b/src/components/ConfigurationHelp.tsx
@@ -33,7 +33,7 @@ export const ConfigurationHelp = ({ authenticationType }: Props) => {
                 Click <strong>Create Credentials</strong> and then click <strong>API key</strong>.
               </li>
               <li>
-                Make sure to enable the{' '}           
+                Make sure to enable the{' '}
                 <a
                   href="https://console.cloud.google.com/apis/library/sheets.googleapis.com"
                   target="_blank"

--- a/src/components/ConfigurationHelp.tsx
+++ b/src/components/ConfigurationHelp.tsx
@@ -33,6 +33,18 @@ export const ConfigurationHelp = ({ authenticationType }: Props) => {
                 Click <strong>Create Credentials</strong> and then click <strong>API key</strong>.
               </li>
               <li>
+                Ensure you have enabled the {''}               
+                <a
+                  href="https://console.cloud.google.com/apis/library/sheets.googleapis.com"
+                  target="_blank"
+                  rel="noreferrer noopener"
+                  style={{ color: theme.colors.text.link }}
+                >
+                  Google Sheets API
+                </a>{' '}
+                for your token in the Google API Console.
+              </li>
+              <li>
                 Copy the key and paste it in the API Key field above. The file contents are encrypted and saved in the
                 Grafana database.
               </li>

--- a/src/components/ConfigurationHelp.tsx
+++ b/src/components/ConfigurationHelp.tsx
@@ -33,16 +33,15 @@ export const ConfigurationHelp = ({ authenticationType }: Props) => {
                 Click <strong>Create Credentials</strong> and then click <strong>API key</strong>.
               </li>
               <li>
-                Make sure to enable the{' '}
+                Before using Google APIs, you need to turn them on in a Google Cloud project.{' '}
                 <a
                   href="https://console.cloud.google.com/apis/library/sheets.googleapis.com"
                   target="_blank"
                   rel="noreferrer noopener"
                   style={{ color: theme.colors.text.link }}
                 >
-                  Google Sheets API
-                </a>{' '}
-                in your Google API Console to enable access with your token.
+                  Enable the API
+                </a>
               </li>
               <li>
                 Copy the key and paste it in the API Key field above. The file contents are encrypted and saved in the

--- a/src/components/ConfigurationHelp.tsx
+++ b/src/components/ConfigurationHelp.tsx
@@ -33,7 +33,7 @@ export const ConfigurationHelp = ({ authenticationType }: Props) => {
                 Click <strong>Create Credentials</strong> and then click <strong>API key</strong>.
               </li>
               <li>
-                Ensure you have enabled the {''}               
+                Make sure to enable the{' '}           
                 <a
                   href="https://console.cloud.google.com/apis/library/sheets.googleapis.com"
                   target="_blank"
@@ -42,7 +42,7 @@ export const ConfigurationHelp = ({ authenticationType }: Props) => {
                 >
                   Google Sheets API
                 </a>{' '}
-                for your token in the Google API Console.
+                in your Google API Console to enable access with your token.
               </li>
               <li>
                 Copy the key and paste it in the API Key field above. The file contents are encrypted and saved in the


### PR DESCRIPTION
I encountered challenges while setting up the Google Sheets data source, and after much effort, I discovered a crucial step not covered in the existing documentation. A randomly found YouTube video highlighted the necessity of enabling Google Sheets API for created token. I propose adding this step to our documentation to save users, like myself, from the frustration of troubleshooting for extended periods when configuring a Google Sheets data source with a token.