### PR TITLE
Percentages: Fix showing of correct values 

### DIFF
--- a/pkg/googlesheets/columndefinition.go
+++ b/pkg/googlesheets/columndefinition.go
@@ -133,7 +133,7 @@ func (cd *ColumnDefinition) checkUnit(cellData *sheets.CellData) {
 			}
 		}
 	case "PERCENT":
-		cd.units["percent"] = true
+		cd.units["percentunit"] = true
 	case "CURRENCY":
 		for unit, unitID := range unitMappings {
 			if strings.Contains(cellData.FormattedValue, unit) {


### PR DESCRIPTION
Fixes https://github.com/grafana/google-sheets-datasource/issues/155

In this PR we are fixing showing of percent values when using data source. Previously, `percent` unit (which is `Percent (0-100)` in the UI)v  was used which meant the received number was furthermore dividied by 100. To fix this, we are using `percentunit` (`Percent (0.0-1.0)` instead) that does not firthermore divide the values.


<img width="1102" alt="image" src="https://github.com/grafana/google-sheets-datasource/assets/30407135/45ce9963-17c8-4de0-9170-fa5b5a2c1e9e">

**Fixed:**

https://github.com/grafana/google-sheets-datasource/assets/30407135/13d7052b-2f8d-4418-b9a1-55d92ee3e11c

**Broken (current main):**

https://github.com/grafana/google-sheets-datasource/assets/30407135/7492573a-78c6-4581-bfa8-1e397870b887
