### PR TITLE
handle unknown non-api errors

### DIFF
--- a/pkg/googlesheets/googlesheets.go
+++ b/pkg/googlesheets/googlesheets.go
@@ -109,10 +109,9 @@ func (gs *GoogleSheets) getSheetData(client client, qm *models.QueryModel) (*she
 			}
 			log.DefaultLogger.Error(apiErr.Error())
 			return nil, nil, errors.New("unknown API error")
-		} else {
-			log.DefaultLogger.Error("unknown error", "err", err)
-			return nil, nil, errors.New("unknown error")
 		}
+		log.DefaultLogger.Error("unknown error", "err", err)
+		return nil, nil, errors.New("unknown error")
 	}
 
 	if result.Properties.TimeZone != "" {

--- a/pkg/googlesheets/googlesheets.go
+++ b/pkg/googlesheets/googlesheets.go
@@ -109,6 +109,9 @@ func (gs *GoogleSheets) getSheetData(client client, qm *models.QueryModel) (*she
 			}
 			log.DefaultLogger.Error(apiErr.Error())
 			return nil, nil, errors.New("unknown API error")
+		} else {
+			log.DefaultLogger.Error("unknown error", "err", err)
+			return nil, nil, errors.New("unknown error")
 		}
 	}
 


### PR DESCRIPTION
if you check the error-handling logic, it goes roughly like this:

```go
	if err != nil {
		if apiErr, ok := err.(*googleapi.Error); ok {
                         // handle api error
		}
	}

        // process the result
```

so, if we have an error, that is not an api-error, we just don't handle it at all, and we continue processing the result (even though we have an error).

this PR simply adds an `else` branch to handle non-api errors.

how to test:
1. run a google-sheets query, make sure it works
2. turn off the internet on your laptop 😁 , and repeat the query
3. you should see the error message "unknown error" (in main-branch at this point you'll see `An error occurred within the plugin` )