### PR TITLE
Chore: Fix context canceled error to be marked as downstream

### DIFF
--- a/pkg/googlesheets/datasource.go
+++ b/pkg/googlesheets/datasource.go
@@ -98,7 +98,7 @@ func (d *Datasource) QueryData(ctx context.Context, req *backend.QueryDataReques
 		}
 		dr := d.googlesheets.Query(ctx, q.RefID, queryModel, *config, q.TimeRange)
 		if dr.Error != nil {
-			if (dr.ErrorSource == backend.ErrorSourceDownstream) {
+			if dr.ErrorSource == backend.ErrorSourceDownstream {
 				// For downstream errors, we log them as warnings as they are not caused by the plugin itself
 				log.DefaultLogger.Warn("Query failed", "refId", q.RefID, "error", dr.Error, "errorsource", dr.ErrorSource)
 			} else {

--- a/pkg/googlesheets/datasource.go
+++ b/pkg/googlesheets/datasource.go
@@ -98,7 +98,12 @@ func (d *Datasource) QueryData(ctx context.Context, req *backend.QueryDataReques
 		}
 		dr := d.googlesheets.Query(ctx, q.RefID, queryModel, *config, q.TimeRange)
 		if dr.Error != nil {
-			log.DefaultLogger.Error("Query failed", "refId", q.RefID, "error", dr.Error, "errorsource", dr.ErrorSource)
+			if (dr.ErrorSource == backend.ErrorSourceDownstream) {
+				// For downstream errors, we log them as warnings as they are not caused by the plugin itself
+				log.DefaultLogger.Warn("Query failed", "refId", q.RefID, "error", dr.Error, "errorsource", dr.ErrorSource)
+			} else {
+				log.DefaultLogger.Error("Query failed", "refId", q.RefID, "error", dr.Error, "errorsource", dr.ErrorSource)
+			}
 		}
 		response.Responses[q.RefID] = dr
 	}

--- a/pkg/googlesheets/googlesheets_test.go
+++ b/pkg/googlesheets/googlesheets_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/grafana/google-sheets-datasource/pkg/models"
+
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 
 	"github.com/patrickmn/go-cache"


### PR DESCRIPTION
This PR adds correct handling for context canceled and deadline exceeded errors. I noticed that these errors were being considered plugin errors [in the logs](https://ops.grafana-ops.net/goto/TOv0svrSg?orgId=1): `logger=plugin.metrics t=2024-07-31T17:42:37.685899914Z level=error msg="Partial data response error" refID=A status=500 error="net/http: request canceled (Client.Timeout or context cancellation while reading body)" statusSource=plugin`

So I am fixing that here and adding a test.

I have also updated the log level for errors from requests, changing it from "error" to "warn" (warnings should be used for errors not caused by us).