### PR TITLE
Chore: Improve logging, add response size logs

### DIFF
--- a/pkg/googlesheets/datasource.go
+++ b/pkg/googlesheets/datasource.go
@@ -43,14 +43,15 @@ func NewDatasource(_ context.Context, _ backend.DataSourceInstanceSettings) (ins
 
 // CheckHealth checks if the datasource is working.
 func (d *Datasource) CheckHealth(ctx context.Context, req *backend.CheckHealthRequest) (*backend.CheckHealthResult, error) {
+	logger := backend.Logger.FromContext(ctx)
 	res := &backend.CheckHealthResult{}
-	log.DefaultLogger.Debug("CheckHealth called")
+	logger.Debug("CheckHealth called")
 	config, err := models.LoadSettings(req.PluginContext)
 
 	if err != nil {
 		res.Status = backend.HealthStatusError
 		res.Message = "Unable to load settings"
-		log.DefaultLogger.Debug(err.Error())
+		logger.Debug(err.Error())
 		return res, nil
 	}
 
@@ -58,7 +59,7 @@ func (d *Datasource) CheckHealth(ctx context.Context, req *backend.CheckHealthRe
 	if err != nil {
 		res.Status = backend.HealthStatusError
 		res.Message = "Unable to create client"
-		log.DefaultLogger.Debug(err.Error())
+		logger.Debug(err.Error())
 		return res, nil
 	}
 
@@ -66,7 +67,7 @@ func (d *Datasource) CheckHealth(ctx context.Context, req *backend.CheckHealthRe
 	if err != nil {
 		res.Status = backend.HealthStatusError
 		res.Message = "Permissions check failed"
-		log.DefaultLogger.Debug(err.Error())
+		logger.Debug(err.Error())
 		return res, nil
 	}
 
@@ -77,10 +78,11 @@ func (d *Datasource) CheckHealth(ctx context.Context, req *backend.CheckHealthRe
 
 // QueryData handles queries to the datasource.
 func (d *Datasource) QueryData(ctx context.Context, req *backend.QueryDataRequest) (*backend.QueryDataResponse, error) {
+	logger := backend.Logger.FromContext(ctx)
 	// create response struct
 	response := backend.NewQueryDataResponse()
 
-	log.DefaultLogger.Debug("QueryData called", "numQueries", len(req.Queries))
+	logger.Debug("QueryData called", "numQueries", len(req.Queries))
 
 	config, err := models.LoadSettings(req.PluginContext)
 	if err != nil {
@@ -100,9 +102,9 @@ func (d *Datasource) QueryData(ctx context.Context, req *backend.QueryDataReques
 		if dr.Error != nil {
 			if dr.ErrorSource == backend.ErrorSourceDownstream {
 				// For downstream errors, we log them as warnings as they are not caused by the plugin itself
-				log.DefaultLogger.Warn("Query failed", "refId", q.RefID, "error", dr.Error, "errorsource", dr.ErrorSource)
+				logger.Debug("Query failed", "refId", q.RefID, "error", dr.Error, "errorsource", dr.ErrorSource)
 			} else {
-				log.DefaultLogger.Error("Query failed", "refId", q.RefID, "error", dr.Error, "errorsource", dr.ErrorSource)
+				logger.Error("Query failed", "refId", q.RefID, "error", dr.Error, "errorsource", dr.ErrorSource)
 			}
 		}
 		response.Responses[q.RefID] = dr

--- a/pkg/googlesheets/googleclient.go
+++ b/pkg/googlesheets/googleclient.go
@@ -61,6 +61,13 @@ func NewGoogleClient(ctx context.Context, settings models.DatasourceSettings) (*
 		return nil, err
 	}
 
+	// We cannot retrieve response information (such as size) for API key authentication 
+	// because we are not passing the httpClient to the service, and as a result, middleware cannot be provided. 
+	// Therefore, we are logging here to indicate that response information will not be retrieved, allowing us to track this behavior.
+	// This approach is acceptable for now since we are creating a new client for each request. 
+	// If this changes in the future, the logging should be moved to a location where it handles logging for each query.
+	logIfNotAbleToRetrieveResponseInfo(ctx, settings)
+
 	return &GoogleClient{
 		sheetsService: sheetsService,
 		driveService:  driveService,
@@ -225,7 +232,7 @@ func newHTTPClient(settings models.DatasourceSettings, opts httpclient.Options, 
 		return nil, err
 	}
 
-	opts.Middlewares = append(opts.Middlewares, m, errorsource.Middleware("grafana-googlesheets-datasource"))
+	opts.Middlewares = append(opts.Middlewares, m, errorsource.Middleware("grafana-googlesheets-datasource"), ResponseInfoMiddleware())
 	return httpclient.New(opts)
 }
 

--- a/pkg/googlesheets/googlesheets_bench_test.go
+++ b/pkg/googlesheets/googlesheets_bench_test.go
@@ -1,6 +1,7 @@
 package googlesheets
 
 import (
+	"context"
 	"testing"
 
 	"github.com/grafana/google-sheets-datasource/pkg/models"
@@ -21,7 +22,7 @@ func BenchmarkTransformMixedSheetToDataFrame(b *testing.B) {
 	meta := make(map[string]any)
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		frame, err := gsd.transformSheetToDataFrame(sheet.Sheets[0].Data[0], meta, "ref1", &qm)
+		frame, err := gsd.transformSheetToDataFrame(context.Background(), sheet.Sheets[0].Data[0], meta, "ref1", &qm)
 		require.NoError(b, err)
 		Frame = frame
 	}
@@ -35,7 +36,7 @@ func BenchmarkTransformMixedSheetWithInvalidDateToDataFrame(b *testing.B) {
 	meta := make(map[string]any)
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		frame, err := gsd.transformSheetToDataFrame(sheet.Sheets[0].Data[0], meta, "ref1", &qm)
+		frame, err := gsd.transformSheetToDataFrame(context.Background(), sheet.Sheets[0].Data[0], meta, "ref1", &qm)
 		require.NoError(b, err)
 		Frame = frame
 	}

--- a/pkg/googlesheets/googlesheets_test.go
+++ b/pkg/googlesheets/googlesheets_test.go
@@ -69,13 +69,13 @@ func TestGooglesheets(t *testing.T) {
 
 			client.On("GetSpreadsheet", qm.Spreadsheet, qm.Range, true).Return(loadTestSheet("./testdata/mixed-data.json"))
 
-			_, meta, err := gsd.getSheetData(client, &qm)
+			_, meta, err := gsd.getSheetData(context.Background(), client, &qm)
 			require.NoError(t, err)
 
 			assert.False(t, meta["hit"].(bool))
 			assert.Equal(t, 1, gsd.Cache.ItemCount())
 
-			_, meta, err = gsd.getSheetData(client, &qm)
+			_, meta, err = gsd.getSheetData(context.Background(), client, &qm)
 			require.NoError(t, err)
 			assert.True(t, meta["hit"].(bool))
 			assert.Equal(t, 1, gsd.Cache.ItemCount())
@@ -92,7 +92,7 @@ func TestGooglesheets(t *testing.T) {
 
 			client.On("GetSpreadsheet", qm.Spreadsheet, qm.Range, true).Return(loadTestSheet("./testdata/mixed-data.json"))
 
-			_, meta, err := gsd.getSheetData(client, &qm)
+			_, meta, err := gsd.getSheetData(context.Background(), client, &qm)
 			require.NoError(t, err)
 
 			assert.False(t, meta["hit"].(bool))
@@ -115,7 +115,7 @@ func TestGooglesheets(t *testing.T) {
 				Message: "Not found",
 			})
 
-			_, _, err := gsd.getSheetData(client, qm)
+			_, _, err := gsd.getSheetData(context.Background(), client, qm)
 
 			assert.Error(t, err)
 			assert.Equal(t, "spreadsheet not found", err.Error())
@@ -137,7 +137,7 @@ func TestGooglesheets(t *testing.T) {
 				Message: "Forbidden",
 			})
 
-			_, _, err := gsd.getSheetData(client, qm)
+			_, _, err := gsd.getSheetData(context.Background(), client, qm)
 
 			assert.Error(t, err)
 			assert.Equal(t, "google API Error 403", err.Error())
@@ -157,7 +157,7 @@ func TestGooglesheets(t *testing.T) {
 			}
 			client.On("GetSpreadsheet", qm.Spreadsheet, qm.Range, true).Return(&sheets.Spreadsheet{}, context.Canceled)
 
-			_, _, err := gsd.getSheetData(client, qm)
+			_, _, err := gsd.getSheetData(context.Background(), client, qm)
 
 			assert.Error(t, err)
 			assert.Equal(t, context.Canceled.Error(), err.Error())
@@ -179,7 +179,7 @@ func TestGooglesheets(t *testing.T) {
 
 			client.On("GetSpreadsheet", qm.Spreadsheet, qm.Range, true).Return(&sheets.Spreadsheet{}, &net.OpError{Err: context.DeadlineExceeded})
 
-			_, _, err := gsd.getSheetData(client, qm)
+			_, _, err := gsd.getSheetData(context.Background(), client, qm)
 
 			assert.Error(t, err)
 			assert.True(t, backend.IsDownstreamError(err))
@@ -202,7 +202,7 @@ func TestGooglesheets(t *testing.T) {
 				Message: "",
 			})
 
-			_, _, err := gsd.getSheetData(client, qm)
+			_, _, err := gsd.getSheetData(context.Background(), client, qm)
 
 			assert.Error(t, err)
 			assert.Equal(t, "unknown API error", err.Error())
@@ -221,7 +221,7 @@ func TestGooglesheets(t *testing.T) {
 		qm := models.QueryModel{Range: "A1:O", Spreadsheet: "someId", CacheDurationSeconds: 10}
 
 		meta := make(map[string]any)
-		frame, err := gsd.transformSheetToDataFrame(sheet.Sheets[0].Data[0], meta, "ref1", &qm)
+		frame, err := gsd.transformSheetToDataFrame(context.Background(), sheet.Sheets[0].Data[0], meta, "ref1", &qm)
 		require.NoError(t, err)
 		require.Equal(t, "ref1", frame.Name)
 
@@ -260,7 +260,7 @@ func TestGooglesheets(t *testing.T) {
 		qm := models.QueryModel{Range: "A2", Spreadsheet: "someId", CacheDurationSeconds: 10}
 
 		meta := make(map[string]any)
-		frame, err := gsd.transformSheetToDataFrame(sheet.Sheets[0].Data[0], meta, "ref1", &qm)
+		frame, err := gsd.transformSheetToDataFrame(context.Background(), sheet.Sheets[0].Data[0], meta, "ref1", &qm)
 		require.NoError(t, err)
 		require.Equal(t, "ref1", frame.Name)
 

--- a/pkg/googlesheets/response_info_middleware.go
+++ b/pkg/googlesheets/response_info_middleware.go
@@ -23,14 +23,14 @@ func RoundTripper(_ httpclient.Options, next http.RoundTripper) http.RoundTrippe
 		}
 
 		res.Body = httpclient.CountBytesReader(res.Body, func(size int64) {
-			backend.Logger.FromContext(req.Context()).Debug("downstream response info", "bytes", size, "url", req.URL.String(), "retrieved", true)
+			backend.Logger.FromContext(req.Context()).Debug("Downstream response info", "bytes", size, "url", req.URL.String(), "retrieved", true)
 		})
 		return res, err
 	})
 }
 
 func logIfNotAbleToRetrieveResponseInfo(ctx context.Context, settings models.DatasourceSettings) {
-	if settings.AuthType == "key" && len(settings.APIKey) > 0 {
-		backend.Logger.FromContext(ctx).Debug("downstream response info", "retrieved", false)
+	if settings.AuthenticationType == "key" && len(settings.APIKey) > 0 {
+		backend.Logger.FromContext(ctx).Debug("Downstream response info", "retrieved", false)
 	}
 }

--- a/pkg/googlesheets/response_info_middleware.go
+++ b/pkg/googlesheets/response_info_middleware.go
@@ -1,0 +1,36 @@
+package googlesheets
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/grafana/google-sheets-datasource/pkg/models"
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/grafana/grafana-plugin-sdk-go/backend/httpclient"
+)
+
+const ResponseInfoMiddlewareName = "response-info"
+
+func ResponseInfoMiddleware() httpclient.Middleware {
+	return httpclient.NamedMiddlewareFunc(ResponseInfoMiddlewareName, RoundTripper)
+}
+
+func RoundTripper(_ httpclient.Options, next http.RoundTripper) http.RoundTripper {
+	return httpclient.RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		res, err := next.RoundTrip(req)
+		if err != nil {
+			return nil, err
+		}
+
+		res.Body = httpclient.CountBytesReader(res.Body, func(size int64) {
+			backend.Logger.FromContext(req.Context()).Debug("downstream response info", "bytes", size, "url", req.URL.String(), "retrieved", true)
+		})
+		return res, err
+	})
+}
+
+func logIfNotAbleToRetrieveResponseInfo(ctx context.Context, settings models.DatasourceSettings) {
+	if settings.AuthType == "key" && len(settings.APIKey) > 0 {
+		backend.Logger.FromContext(ctx).Debug("downstream response info", "retrieved", false)
+	}
+}


### PR DESCRIPTION
This PR:

- Fixes logging from context. For all logs, we weren't creating logger from context and therefore we were missing context params in logs
- Adds logging of response size trough using middleware
- Adds logging for not being able to log response size - the same log as when we capture response info, but we use `retrieved=false` instead

Logs when retrieved response info with jwt auth and gce default service account (unfortunately, here I was not able to find a way to pass context, so we are not logging context params):
```
{"@level":"debug","@message":"Downstream response info","@timestamp":"2024-09-18T13:54:56.277022+02:00","bytes":61,"retrieved":true,"url":"https://www.googleapis.com/drive/v3/files?alt=json\u0026prettyPr..."}
```

Logs when can't retrieve response info with apiKey: 
```
{"@level":"debug","@message":"Downstream response info","@timestamp":"2024-09-18T14:12:09.180909+02:00","dsName":"cold-plunges","dsUID":"e6ea1a43-c46a-4d27-9a97-afaabe4c91f4","endpoint":"queryData","pluginID":"grafana-googlesheets-datasource","retrieved":false,"uname":"admin"}
```