### PR TITLE
Update dependencies to path-to-regexp 1.9.0 and grafana-plugin-sdk-go 0.251.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## 1.2.14
+
+- Bump path-to-regexp from 1.8.0 to 1.9.0 #268
+- Bump github.com/grafana/grafana-plugin-sdk-go from 0.250.0 to 0.251.0. #275
+
 ## 1.2.13
 
 - Update `github.com/grafana/grafana-plugin-sdk-go` to `v0.248.0`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grafana-google-sheets-datasource",
-  "version": "1.2.13",
+  "version": "1.2.14",
   "description": "Load data from google sheets in grafana",
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",


### PR DESCRIPTION
This pull request updates the dependencies of the project to use path-to-regexp version 1.9.0 and grafana-plugin-sdk-go version 0.251.0. These updates address issues #268 and #275 respectively.