### PR TITLE
Use `backend.IsDownstreamHTTPError` to set error source for known http downstream errors

### DIFF
--- a/pkg/googlesheets/googlesheets.go
+++ b/pkg/googlesheets/googlesheets.go
@@ -121,6 +121,11 @@ func (gs *GoogleSheets) getSheetData(ctx context.Context, client client, qm *mod
 			return nil, nil, errWithSource
 		}
 
+		if backend.IsDownstreamHTTPError(err) {
+			errWithSource := errorsource.DownstreamError(err, false)
+			return nil, nil, errWithSource
+		}
+		
 		netErr, neErrOk := err.(net.Error)
 		if neErrOk {
 			var retrieveErr *oauth2.RetrieveError

--- a/pkg/googlesheets/googlesheets.go
+++ b/pkg/googlesheets/googlesheets.go
@@ -125,7 +125,7 @@ func (gs *GoogleSheets) getSheetData(ctx context.Context, client client, qm *mod
 			errWithSource := errorsource.DownstreamError(err, false)
 			return nil, nil, errWithSource
 		}
-		
+
 		netErr, neErrOk := err.(net.Error)
 		if neErrOk {
 			var retrieveErr *oauth2.RetrieveError


### PR DESCRIPTION
This PR uses newly introduced `backend.IsDownstreamHTTPError` method to mark potential http downstream errors as downstream. 