### PR TITLE
Release 1.2.18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## 1.2.18
+
+- Backend dependencies update
+- Readme changes
+- Replace @grafana/experimental with @grafana/plugin-ui (#294)
+
 ## 1.2.17
 
 - Improve data source documentation

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grafana-google-sheets-datasource",
-  "version": "1.2.17",
+  "version": "1.2.18",
   "description": "Load data from google sheets in grafana",
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",


### PR DESCRIPTION
Bump the version to 1.2.18 and document notable changes including backend dependencies update, README modifications, and a package replacement.