### PR TITLE
Swap json.Unmarshal with jsoniter.Unmarshal

### DIFF
--- a/cspell.config.json
+++ b/cspell.config.json
@@ -29,7 +29,9 @@
     "testid",
     "tokenprovider",
     "typecheck",
-    "uplot"
+    "uplot",
+    "bestmemjson",
+    "jsoniter"
   ],
   "language": "en-US"
 }

--- a/pkg/bestmemjson/bestmemjson.go
+++ b/pkg/bestmemjson/bestmemjson.go
@@ -1,0 +1,22 @@
+// Package bestmemjson provides JSON operations using the most memory-efficient implementation
+// based on benchmark testing. It uses encoding/json for Marshal operations and
+// jsoniter for Unmarshal operations.
+package bestmemjson
+
+import (
+	"encoding/json"
+
+	jsoniter "github.com/json-iterator/go"
+)
+
+// Marshal encodes the input using encoding/json Marshal which uses less memory
+// than jsoniter for Marshal operations (112B vs 120B per op)
+func Marshal(v interface{}) ([]byte, error) {
+	return json.Marshal(v)
+}
+
+// Unmarshal decodes the input using jsoniter Unmarshal which uses less memory
+// than encoding/json for Unmarshal operations (200B vs 352B per op)
+func Unmarshal(data []byte, v interface{}) error {
+	return jsoniter.Unmarshal(data, v)
+}

--- a/pkg/bestmemjson/bestmemjson_test.go
+++ b/pkg/bestmemjson/bestmemjson_test.go
@@ -1,0 +1,127 @@
+package bestmemjson
+
+import (
+	"encoding/json"
+	"testing"
+
+	jsoniter "github.com/json-iterator/go"
+	"github.com/stretchr/testify/assert"
+)
+
+type testStruct struct {
+	String  string `json:"string"`
+	Number  int    `json:"number"`
+	Boolean bool   `json:"boolean"`
+	Array   []int  `json:"array"`
+}
+
+var testJSON = []byte(`{
+	"string": "test string",
+	"number": 42,
+	"boolean": true,
+	"array": [1, 2, 3, 4, 5]
+}`)
+
+var testData = &testStruct{
+	String:  "test string",
+	Number:  42,
+	Boolean: true,
+	Array:   []int{1, 2, 3, 4, 5},
+}
+
+func TestBestMemJSONEfficiency(t *testing.T) {
+	t.Run("Marshal memory efficiency", func(t *testing.T) {
+		// Create sub-benchmarks to measure memory
+		standardResult := testing.Benchmark(func(b *testing.B) {
+			b.ResetTimer()
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				_, _ = json.Marshal(testData)
+			}
+		})
+
+		jsoniterResult := testing.Benchmark(func(b *testing.B) {
+			b.ResetTimer()
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				_, _ = jsoniter.Marshal(testData)
+			}
+		})
+
+		bestmemResult := testing.Benchmark(func(b *testing.B) {
+			b.ResetTimer()
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				_, _ = Marshal(testData)
+			}
+		})
+
+		// Print the actual memory usage for verification
+		t.Logf("Memory usage per operation:\n"+
+			"encoding/json: %d bytes/op, %d allocs/op\n"+
+			"jsoniter: %d bytes/op, %d allocs/op\n"+
+			"bestmemjson: %d bytes/op, %d allocs/op",
+			standardResult.AllocedBytesPerOp(),
+			standardResult.AllocsPerOp(),
+			jsoniterResult.AllocedBytesPerOp(),
+			jsoniterResult.AllocsPerOp(),
+			bestmemResult.AllocedBytesPerOp(),
+			bestmemResult.AllocsPerOp())
+
+		// Verify bestmemjson is using the most memory-efficient implementation
+		assert.LessOrEqual(t, bestmemResult.AllocedBytesPerOp(), standardResult.AllocedBytesPerOp(),
+			"bestmemjson.Marshal should not use more memory than encoding/json.Marshal")
+		assert.LessOrEqual(t, bestmemResult.AllocedBytesPerOp(), jsoniterResult.AllocedBytesPerOp(),
+			"bestmemjson.Marshal should not use more memory than jsoniter.Marshal")
+	})
+
+	t.Run("Unmarshal memory efficiency", func(t *testing.T) {
+		var standardModel, jsoniterModel, bestmemModel testStruct
+
+		standardResult := testing.Benchmark(func(b *testing.B) {
+			b.ResetTimer()
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				_ = json.Unmarshal(testJSON, &standardModel)
+			}
+		})
+
+		jsoniterResult := testing.Benchmark(func(b *testing.B) {
+			b.ResetTimer()
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				_ = jsoniter.Unmarshal(testJSON, &jsoniterModel)
+			}
+		})
+
+		bestmemResult := testing.Benchmark(func(b *testing.B) {
+			b.ResetTimer()
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				_ = Unmarshal(testJSON, &bestmemModel)
+			}
+		})
+
+		// Print the actual memory usage for verification
+		t.Logf("Memory usage per operation:\n"+
+			"encoding/json: %d bytes/op, %d allocs/op\n"+
+			"jsoniter: %d bytes/op, %d allocs/op\n"+
+			"bestmemjson: %d bytes/op, %d allocs/op",
+			standardResult.AllocedBytesPerOp(),
+			standardResult.AllocsPerOp(),
+			jsoniterResult.AllocedBytesPerOp(),
+			jsoniterResult.AllocsPerOp(),
+			bestmemResult.AllocedBytesPerOp(),
+			bestmemResult.AllocsPerOp())
+
+		// Verify bestmemjson is using the most memory-efficient implementation
+		assert.LessOrEqual(t, bestmemResult.AllocedBytesPerOp(), standardResult.AllocedBytesPerOp(),
+			"bestmemjson.Unmarshal should not use more memory than encoding/json.Unmarshal")
+		assert.LessOrEqual(t, bestmemResult.AllocedBytesPerOp(), jsoniterResult.AllocedBytesPerOp(),
+			"bestmemjson.Unmarshal should not use more memory than jsoniter.Unmarshal")
+
+		// Verify all implementations produce the same result
+		assert.Equal(t, standardModel, bestmemModel, "bestmemjson.Unmarshal should produce same result as encoding/json")
+		assert.Equal(t, jsoniterModel, bestmemModel, "bestmemjson.Unmarshal should produce same result as jsoniter")
+	})
+}

--- a/pkg/bestmemjson/bestmemjson_test.go
+++ b/pkg/bestmemjson/bestmemjson_test.go
@@ -48,7 +48,7 @@ func TestBestMemJSONEfficiency(t *testing.T) {
 			}
 		})
 
-		bestmemResult := testing.Benchmark(func(b *testing.B) {
+		bestMemResult := testing.Benchmark(func(b *testing.B) {
 			b.ResetTimer()
 			b.ReportAllocs()
 			for i := 0; i < b.N; i++ {
@@ -65,18 +65,18 @@ func TestBestMemJSONEfficiency(t *testing.T) {
 			standardResult.AllocsPerOp(),
 			jsoniterResult.AllocedBytesPerOp(),
 			jsoniterResult.AllocsPerOp(),
-			bestmemResult.AllocedBytesPerOp(),
-			bestmemResult.AllocsPerOp())
+			bestMemResult.AllocedBytesPerOp(),
+			bestMemResult.AllocsPerOp())
 
 		// Verify bestmemjson is using the most memory-efficient implementation
-		assert.LessOrEqual(t, bestmemResult.AllocedBytesPerOp(), standardResult.AllocedBytesPerOp(),
+		assert.LessOrEqual(t, bestMemResult.AllocedBytesPerOp(), standardResult.AllocedBytesPerOp(),
 			"bestmemjson.Marshal should not use more memory than encoding/json.Marshal")
-		assert.LessOrEqual(t, bestmemResult.AllocedBytesPerOp(), jsoniterResult.AllocedBytesPerOp(),
+		assert.LessOrEqual(t, bestMemResult.AllocedBytesPerOp(), jsoniterResult.AllocedBytesPerOp(),
 			"bestmemjson.Marshal should not use more memory than jsoniter.Marshal")
 	})
 
 	t.Run("Unmarshal memory efficiency", func(t *testing.T) {
-		var standardModel, jsoniterModel, bestmemModel testStruct
+		var standardModel, jsoniterModel, bestMemModel testStruct
 
 		standardResult := testing.Benchmark(func(b *testing.B) {
 			b.ResetTimer()
@@ -94,11 +94,11 @@ func TestBestMemJSONEfficiency(t *testing.T) {
 			}
 		})
 
-		bestmemResult := testing.Benchmark(func(b *testing.B) {
+		bestMemResult := testing.Benchmark(func(b *testing.B) {
 			b.ResetTimer()
 			b.ReportAllocs()
 			for i := 0; i < b.N; i++ {
-				_ = Unmarshal(testJSON, &bestmemModel)
+				_ = Unmarshal(testJSON, &bestMemModel)
 			}
 		})
 
@@ -111,17 +111,17 @@ func TestBestMemJSONEfficiency(t *testing.T) {
 			standardResult.AllocsPerOp(),
 			jsoniterResult.AllocedBytesPerOp(),
 			jsoniterResult.AllocsPerOp(),
-			bestmemResult.AllocedBytesPerOp(),
-			bestmemResult.AllocsPerOp())
+			bestMemResult.AllocedBytesPerOp(),
+			bestMemResult.AllocsPerOp())
 
 		// Verify bestmemjson is using the most memory-efficient implementation
-		assert.LessOrEqual(t, bestmemResult.AllocedBytesPerOp(), standardResult.AllocedBytesPerOp(),
+		assert.LessOrEqual(t, bestMemResult.AllocedBytesPerOp(), standardResult.AllocedBytesPerOp(),
 			"bestmemjson.Unmarshal should not use more memory than encoding/json.Unmarshal")
-		assert.LessOrEqual(t, bestmemResult.AllocedBytesPerOp(), jsoniterResult.AllocedBytesPerOp(),
+		assert.LessOrEqual(t, bestMemResult.AllocedBytesPerOp(), jsoniterResult.AllocedBytesPerOp(),
 			"bestmemjson.Unmarshal should not use more memory than jsoniter.Unmarshal")
 
 		// Verify all implementations produce the same result
-		assert.Equal(t, standardModel, bestmemModel, "bestmemjson.Unmarshal should produce same result as encoding/json")
-		assert.Equal(t, jsoniterModel, bestmemModel, "bestmemjson.Unmarshal should produce same result as jsoniter")
+		assert.Equal(t, standardModel, bestMemModel, "bestmemjson.Unmarshal should produce same result as encoding/json")
+		assert.Equal(t, jsoniterModel, bestMemModel, "bestmemjson.Unmarshal should produce same result as jsoniter")
 	})
 }

--- a/pkg/googlesheets/datasource.go
+++ b/pkg/googlesheets/datasource.go
@@ -2,11 +2,11 @@ package googlesheets
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"time"
 
+	"github.com/grafana/google-sheets-datasource/pkg/bestmemjson"
 	"github.com/grafana/google-sheets-datasource/pkg/models"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
@@ -123,7 +123,7 @@ func writeResult(rw http.ResponseWriter, path string, val any, err error) {
 		response[path] = val
 	}
 
-	body, err := json.Marshal(response)
+	body, err := bestmemjson.Marshal(response)
 	if err != nil {
 		body = []byte(err.Error())
 		code = http.StatusInternalServerError

--- a/pkg/models/query.go
+++ b/pkg/models/query.go
@@ -1,9 +1,9 @@
 package models
 
 import (
-	"encoding/json"
 	"fmt"
 
+	"github.com/grafana/google-sheets-datasource/pkg/bestmemjson"
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 )
 
@@ -23,7 +23,7 @@ type QueryModel struct {
 func GetQueryModel(query backend.DataQuery) (*QueryModel, error) {
 	model := &QueryModel{}
 
-	err := json.Unmarshal(query.JSON, &model)
+	err := bestmemjson.Unmarshal(query.JSON, &model)
 	if err != nil {
 		return nil, fmt.Errorf("error reading query: %s", err.Error())
 	}

--- a/pkg/models/settings.go
+++ b/pkg/models/settings.go
@@ -1,9 +1,9 @@
 package models
 
 import (
-	"encoding/json"
 	"fmt"
 
+	"github.com/grafana/google-sheets-datasource/pkg/bestmemjson"
 	"github.com/grafana/grafana-google-sdk-go/pkg/utils"
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 )
@@ -29,7 +29,7 @@ func LoadSettings(ctx backend.PluginContext) (*DatasourceSettings, error) {
 	model := &DatasourceSettings{}
 
 	settings := ctx.DataSourceInstanceSettings
-	err := json.Unmarshal(settings.JSONData, &model)
+	err := bestmemjson.Unmarshal(settings.JSONData, &model)
 	if err != nil {
 		return nil, fmt.Errorf("error reading settings: %s", err.Error())
 	}


### PR DESCRIPTION
I was looking into some OOMs for this plugin as part of my on call shift and noticed that we are using the standard json package. My understanding is that in [grafana/grafana](https://github.com/search?q=repo%3Agrafana%2Fgrafana+jsoniter&type=code) we have switched to using jsoniter in several places because it is at least in theory more performant. 

I did a benchmark test here and noticed that jsoniter uses significantly less memory (in these test examples anyway) for Unmarshal...but oddly performed worse for Marshal. 

So I made a little package to use whichever one is more performant at the time. But maybe this is overkill and we'd rather just use jsoniter directly and no need for the various performance tests. Btw I used cursor on this and am not a memory usage or bench testing expert so definitely let me know if I'm missing anything! 

a note: it might be interesting to add more realistic test cases here if you have them to see if it is indeed more performant... feel free to take over this pr and do with it whatever calls to you and/or disregard but use it for inspiration. I think after this it might be interesting to start putting size limits but that feels worth discussing as a team potentially with product as I'm not sure what a reasonable limit here would be. But if you want a code example of reading size limits I have linked one in the ticket below:

relates to: https://github.com/grafana/data-sources/issues/50
