### PR TITLE
Add template variables

### DIFF
--- a/docs/sources/_index.md
+++ b/docs/sources/_index.md
@@ -44,12 +44,13 @@ To use the Google Sheets data source plugin, you need:
 - Before using the plugin, first you need to [install](https://grafana.com/docs/grafana/latest/administration/plugin-management/#install-a-plugin) the plugin.
 - To learn how to configure the data source, refer to [Setup](./setup/).
 - To learn how to retrieve spreadsheet data, refer to the [Query Editor](./query-editor/) guide.
+- To create dynamic dashboards with variables, refer to [Variables](./variables/).
 - To quickly visualize spreadsheet data in Grafana, refer to [Create a sample dashboard](./create-a-sample-dashboard/).
 
 ## Get the most out of the plugin
 
 - Add [annotations](/docs/grafana/latest/dashboards/build-dashboards/annotate-visualizations/)
-- Configure and use [variables](https://grafana.com/docs/grafana/latest/dashboards/variables/)
+- Configure and use [variables](./variables/)
 - Apply [transformations](/docs/grafana/latest/panels-visualizations/query-transform-data/transform-data/)
 
 ## Quota

--- a/docs/sources/variables/index.md
+++ b/docs/sources/variables/index.md
@@ -1,0 +1,75 @@
+---
+title: Variables
+description: Learn how to create and use variables with the Google Sheets data source plugin for Grafana.
+keywords:
+  - data source
+  - google sheets
+  - spreadsheets
+  - variables
+  - template variables
+  - dynamic dashboards
+  - dashboard variables
+labels:
+  products:
+    - oss
+    - enterprise
+    - cloud
+weight: 300
+---
+
+# Variables
+
+A variable is a placeholder for a value that you can use in dashboard queries. Variables allow you to create more interactive and dynamic dashboards by replacing hard-coded values with dynamic options. They are displayed as dropdown lists at the top of the dashboard, making it easy to change the data being displayed.
+
+The Google Sheets data source plugin supports two types of variables:
+
+- **Query variables**: Create variables populated with data from your Google Sheets
+- **Template variables**: Use variables in your queries to make them dynamic
+
+## Query variables
+
+Query variables allow you to create dropdown lists populated with data from your Google Sheets. These variables can be used in other queries to create dynamic dashboards.
+
+### Create a query variable
+
+To create a query variable:
+
+1. Go to your dashboard settings.
+1. Click **Variables**.
+1. Click **Add variable**.
+1. In the **Query options** section, select your Google Sheets data source.
+1. Configure your variable query:
+   - **Spreadsheet ID**: Enter the ID of the spreadsheet containing your variable data
+   - **Range**: Specify the range containing your data (e.g., `Sheet1!A1:B10`)
+   - **Value Field**: Select the column to use as the variable value
+   - **Label Field**: Select the column to use as the display text (optional)
+
+### Value and Label fields
+
+- **Value Field**: The column that contains the actual values to be used in queries
+- **Label Field**: The column that contains the display text shown in the dropdown (if different from the value)
+
+If you don't specify a label field, the value field will be used for both the value and display text.
+
+### Example
+
+Consider a Google Sheet with the following data:
+
+| Country Code | Country Name |
+|-------------|--------------|
+| US          | United States |
+| GB          | United Kingdom |
+| CA          | Canada |
+
+To create a country variable:
+
+1. Set **Value Field** to `Country Code`
+2. Set **Label Field** to `Country Name`
+
+This creates a dropdown showing "United States", "United Kingdom", "Canada" but using the values "US", "GB", "CA" in your queries.
+
+## Related topics
+
+- [Query Editor](../query-editor/)
+- [Setup](../setup/)
+- [Grafana Variables documentation](https://grafana.com/docs/grafana/latest/dashboards/variables/) 

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "@swc/jest": "^0.2.26",
     "@testing-library/jest-dom": "6.1.4",
     "@testing-library/react": "14.0.0",
+    "@testing-library/user-event": "^14.6.1",
     "@types/glob": "^8.0.0",
     "@types/jest": "^29.5.0",
     "@types/lodash": "^4.14.194",

--- a/src/DataSource.ts
+++ b/src/DataSource.ts
@@ -10,12 +10,14 @@ import { DataSourceWithBackend, getTemplateSrv } from '@grafana/runtime';
 import { SheetsQuery } from './types';
 import { Observable } from 'rxjs';
 import { trackRequest } from 'tracking';
+import { SheetsVariableSupport } from 'variables';
 
 export class DataSource extends DataSourceWithBackend<SheetsQuery, DataSourceOptions> {
   authType: string;
   constructor(instanceSettings: DataSourceInstanceSettings<DataSourceOptions>) {
     super(instanceSettings);
     this.authType = instanceSettings.jsonData.authenticationType;
+    this.variables = new SheetsVariableSupport(this);
   }
 
   query(request: DataQueryRequest<SheetsQuery>): Observable<DataQueryResponse> {

--- a/src/components/QueryEditor.tsx
+++ b/src/components/QueryEditor.tsx
@@ -53,7 +53,10 @@ export const formatCacheTimeLabel = (s: number = defaultCacheDuration) => {
 export class QueryEditor extends PureComponent<Props> {
   componentDidMount() {
     if (!this.props.query.hasOwnProperty('cacheDurationSeconds')) {
-      this.props.query.cacheDurationSeconds = defaultCacheDuration; // um :(
+      this.props.onChange({
+        ...this.props.query,
+        cacheDurationSeconds: defaultCacheDuration, // um :(
+      });
     }
   }
 

--- a/src/components/VariableQueryEditor.test.tsx
+++ b/src/components/VariableQueryEditor.test.tsx
@@ -1,0 +1,155 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { of } from 'rxjs';
+import { CoreApp } from '@grafana/data';
+import VariableQueryEditor from './VariableQueryEditor';
+import { DataSource } from '../DataSource';
+import { SheetsVariableQuery } from '../types';
+
+// Mock the dependencies
+jest.mock('@grafana/data', () => ({
+  ...jest.requireActual('@grafana/data'),
+  getDefaultTimeRange: jest.fn().mockReturnValue({
+    from: { valueOf: () => 1000 },
+    to: { valueOf: () => 2000 },
+    raw: { from: 'now-1h', to: 'now' },
+  }),
+  CoreApp: {
+    Unknown: 'unknown',
+  },
+}));
+
+// Create a mock datasource factory
+const createMockDataSource = (overrides: Partial<DataSource> = {}): DataSource => {
+  return {
+    query: jest.fn().mockReturnValue(
+      of({
+        data: [
+          {
+            fields: [
+              { name: 'defaultValueField', values: ['item1', 'item2', 'item3'] },
+              { name: 'defaultLabelField', values: ['Item 1', 'Item 2', 'Item 3'] },
+              { name: 'baz', values: ['Category 1', 'Category 2', 'Category 3'] },
+              { name: 'qux', values: ['Category 1', 'Category 2', 'Category 3'] },
+            ],
+          },
+        ],
+      })
+    ),
+    getSpreadSheets: jest.fn(),
+    authType: 'key',
+    ...overrides,
+  } as DataSource;
+};
+
+describe('VariableQueryEditor', () => {
+  let props: {
+    query: SheetsVariableQuery;
+    onChange: jest.Mock;
+    onRunQuery: jest.Mock;
+    datasource: DataSource;
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    props = {
+      datasource: createMockDataSource(),
+      query: {
+        refId: 'A',
+        cacheDurationSeconds: 300,
+        spreadsheet: 'test-sheet-id',
+        valueField: 'defaultValueField',
+        labelField: 'defaultLabelField',
+      },
+      onChange: jest.fn(),
+      onRunQuery: jest.fn(),
+    };
+  });
+
+  test('renders without crashing', async () => {
+    render(<VariableQueryEditor {...props} />);
+    expect(await screen.findByTestId('value-field-select')).toBeInTheDocument();
+    expect(await screen.findByTestId('label-field-select')).toBeInTheDocument();
+  });
+
+  test('fetches column choices on mount', async () => {
+    render(<VariableQueryEditor {...props} />);
+    await waitFor(() => {
+      expect(props.datasource.query).toHaveBeenCalledWith(
+        expect.objectContaining({
+          targets: [{ ...props.query, refId: 'metricFindQuery' }],
+          requestId: 'metricFindQuery',
+          app: CoreApp.Unknown,
+        })
+      );
+    });
+    expect(await screen.findByText('defaultValueField')).toBeInTheDocument();
+    expect(await screen.findByText('defaultLabelField')).toBeInTheDocument();
+    expect(screen.queryByText('baz')).not.toBeInTheDocument();
+  });
+
+  test('shows loading state while fetching choices', async () => {
+    render(<VariableQueryEditor {...props} />);
+    // Should show loading state
+    expect(await screen.findAllByText('Loading...')).toHaveLength(2); // Both selects show loading
+    // Loading should disappear
+    await waitFor(() => {
+      expect(screen.queryByText('Loading...')).not.toBeInTheDocument();
+    });
+  });
+
+  test('shows options for selecting label field', async () => {
+    render(<VariableQueryEditor {...props} />);
+    await waitFor(() => {
+      expect(props.datasource.query).toHaveBeenCalled();
+    });
+
+    // bar is the default value
+    expect(await screen.findByText('defaultLabelField')).toBeInTheDocument();
+    expect(screen.queryByText('baz')).not.toBeInTheDocument();
+
+    userEvent.click(await screen.findByText('defaultLabelField'));
+    expect(await screen.findByText('baz')).toBeInTheDocument();
+    expect(await screen.findByText('qux')).toBeInTheDocument();
+  });
+
+  test('shows options for selecting value field', async () => {
+    render(<VariableQueryEditor {...props} />);
+    await waitFor(() => {
+      expect(props.datasource.query).toHaveBeenCalled();
+    });
+
+    // bar is the default value
+    expect(await screen.findByText('defaultValueField')).toBeInTheDocument();
+    expect(screen.queryByText('baz')).not.toBeInTheDocument();
+
+    userEvent.click(await screen.findByText('defaultValueField'));
+    expect(await screen.findByText('baz')).toBeInTheDocument();
+    expect(await screen.findByText('qux')).toBeInTheDocument();
+  });
+
+  test('updates the query when the value field is changed', async () => {
+    render(<VariableQueryEditor {...props} />);
+    userEvent.click(await screen.findByText('defaultValueField'));
+    userEvent.click(await screen.findByText('qux'));
+    await waitFor(() => {
+      expect(props.onChange).toHaveBeenCalledWith({
+        ...props.query,
+        valueField: 'qux',
+      });
+    });
+  });
+
+  test('updates the query when the label field is changed', async () => {
+    render(<VariableQueryEditor {...props} />);
+    userEvent.click(await screen.findByText('defaultLabelField'));
+    userEvent.click(await screen.findByText('baz'));
+    await waitFor(() => {
+      expect(props.onChange).toHaveBeenCalledWith({
+        ...props.query,
+        labelField: 'baz',
+      });
+    });
+  });
+});

--- a/src/components/VariableQueryEditor.tsx
+++ b/src/components/VariableQueryEditor.tsx
@@ -1,0 +1,112 @@
+import React, { useEffect, useState } from 'react';
+import { InlineFieldRow, InlineFormLabel, Select, useTheme2 } from '@grafana/ui';
+import { QueryEditor } from './QueryEditor';
+import { DataSource } from '../DataSource';
+import { SheetsVariableQuery } from '../types';
+import { CoreApp, Field, getDefaultTimeRange, GrafanaTheme2, SelectableValue } from '@grafana/data';
+import { lastValueFrom } from 'rxjs';
+import { css } from '@emotion/css';
+
+interface Props {
+  query: SheetsVariableQuery;
+  onChange: (query: SheetsVariableQuery) => void;
+  onRunQuery: () => void;
+  datasource: DataSource;
+}
+
+const VariableQueryEditor = (props: Props) => {
+  const [choices, setChoices] = useState<string[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  const { query, datasource, onChange, onRunQuery } = props;
+
+  const theme = useTheme2();
+  const styles = getStyles(theme);
+
+  useEffect(() => {
+    const fetchChoices = async (query: SheetsVariableQuery) => {
+      try {
+        setLoading(true);
+        const res = await lastValueFrom(datasource.query(createRequest(query)));
+        const columns = (res?.data[0]?.fields ?? []).map((f: Field) => f.name);
+        setChoices(columns);
+      } catch (err) {
+        setChoices([]);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchChoices(query);
+  }, [query, datasource]);
+
+  return (
+    <>
+      <QueryEditor query={query} datasource={datasource} onChange={onChange} onRunQuery={onRunQuery} />
+      <InlineFieldRow className={styles.rowSpacing}>
+        <InlineFormLabel
+          width={10}
+          tooltip="This field determines the value used for the variable"
+          className="query-keyword"
+        >
+          Value Field
+        </InlineFormLabel>
+        <Select
+          data-testid="value-field-select"
+          allowCustomValue
+          value={query.valueField}
+          onChange={(opt: SelectableValue<string>) => onChange({ ...query, valueField: opt.value ?? '' })}
+          width={64}
+          placeholder={loading ? 'Loading...' : 'Select'}
+          options={choices.map((opt) => ({ label: opt, value: opt }))}
+        />
+      </InlineFieldRow>
+      <InlineFieldRow className={styles.rowSpacing}>
+        <InlineFormLabel
+          width={10}
+          tooltip="This field determines the text used for the variable"
+          className="query-keyword"
+        >
+          Label Field
+        </InlineFormLabel>
+        <Select
+          data-testid="label-field-select"
+          allowCustomValue
+          value={query.labelField}
+          onChange={(opt: SelectableValue<string>) => onChange({ ...query, labelField: opt.value ?? '' })}
+          width={64}
+          placeholder={loading ? 'Loading...' : 'Select'}
+          options={choices.map((opt) => ({ label: opt, value: opt }))}
+        />
+      </InlineFieldRow>
+    </>
+  );
+};
+
+export default VariableQueryEditor;
+
+const getStyles = (theme: GrafanaTheme2) => {
+  return {
+    rowSpacing: css({
+      marginBottom: theme.spacing(0.5),
+    }),
+  };
+};
+
+// This is used to create a request for the variable query editor
+// We need to add this to satisfy the type checker, but it is not important for executed queries
+const createRequest = (query: SheetsVariableQuery) => {
+  return {
+    targets: [{ ...query, refId: 'metricFindQuery' }],
+    range: getDefaultTimeRange(),
+    requestId: 'metricFindQuery',
+    interval: '1s',
+    intervalMs: 1000,
+    timezone: 'browser',
+    panelId: 1,
+    dashboardUID: '1',
+    scopedVars: {},
+    startTime: Date.now(),
+    app: CoreApp.Unknown,
+  };
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -36,3 +36,8 @@ export interface SheetsQuery extends DataQuery {
   cacheDurationSeconds?: number;
   useTimeFilter?: boolean;
 }
+
+export interface SheetsVariableQuery extends SheetsQuery {
+  valueField?: string;
+  labelField?: string;
+}

--- a/src/variables.test.ts
+++ b/src/variables.test.ts
@@ -1,0 +1,35 @@
+import { queryResponseToVariablesFrame } from './variables';
+import { SheetsVariableQuery } from './types';
+import { toDataFrame } from '@grafana/data';
+
+describe('queryResponseToVariablesFrame', () => {
+  test('transforms response data into value/text format', () => {
+    const query: SheetsVariableQuery = {
+      valueField: 'id',
+      labelField: 'name',
+      spreadsheet: 'test-sheet',
+      range: 'A1:B3',
+      cacheDurationSeconds: 300,
+      refId: 'A',
+    };
+
+    const response = {
+      data: [
+        toDataFrame({
+          fields: [
+            { name: 'id', values: ['1', '2', '3'] },
+            { name: 'name', values: ['Item 1', 'Item 2', 'Item 3'] },
+          ],
+        }),
+      ],
+    };
+
+    const result = queryResponseToVariablesFrame(query, response);
+
+    expect(result.data).toEqual([
+      { value: '1', text: 'Item 1' },
+      { value: '2', text: 'Item 2' },
+      { value: '3', text: 'Item 3' },
+    ]);
+  });
+});

--- a/src/variables.ts
+++ b/src/variables.ts
@@ -1,0 +1,36 @@
+import { map, Observable } from 'rxjs';
+import { CustomVariableSupport, DataQueryResponse, DataQueryRequest, DataFrameView } from '@grafana/data';
+import { DataSource } from './DataSource';
+import VariableQueryEditor from './components/VariableQueryEditor';
+import type { SheetsVariableQuery } from './types';
+
+export class SheetsVariableSupport extends CustomVariableSupport<DataSource, SheetsVariableQuery> {
+  constructor(private readonly datasource: DataSource) {
+    super();
+    this.datasource = datasource;
+    this.query = this.query.bind(this);
+  }
+  editor = VariableQueryEditor;
+  query(request: DataQueryRequest<SheetsVariableQuery>): Observable<DataQueryResponse> {
+    let query = { ...request?.targets[0], refId: 'metricFindQuery' };
+    return this.datasource
+      .query({ ...request, targets: [query] })
+      .pipe(map((response) => ({ ...response, data: response.data || [] })))
+      .pipe(map((response) => queryResponseToVariablesFrame(query, response)));
+  }
+}
+
+export const queryResponseToVariablesFrame = (query: SheetsVariableQuery, response: DataQueryResponse) => {
+  if (response?.data?.length < 1) {
+    return { ...response, data: [] };
+  }
+  const view = new DataFrameView(response.data[0] || {});
+  const data = view
+    .map((item) => {
+      const value = item[query.valueField || ''];
+      const text = item[query.labelField || ''] || value;
+      return { value, text };
+    })
+    .filter((item) => !!item.value && !!item.text);
+  return { ...response, data };
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -2188,6 +2188,11 @@
     "@testing-library/dom" "^9.0.0"
     "@types/react-dom" "^18.0.0"
 
+"@testing-library/user-event@^14.6.1":
+  version "14.6.1"
+  resolved "https://registry.yarnpkg.com/@testing-library/user-event/-/user-event-14.6.1.tgz#13e09a32d7a8b7060fe38304788ebf4197cd2149"
+  integrity sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==
+
 "@tootallnate/once@2":
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-2.0.0.tgz#f544a148d3ab35801c1f633a7441fd87c2e484bf"


### PR DESCRIPTION
Currently, you can't use Google Sheets data source to create template variables. This PR adds template variable functionality. 

Added functionality:

https://github.com/user-attachments/assets/a1a630bf-fd4d-4037-a69e-12ba1100ebc7


This PR keeps it small and is inspired by [github data source implementation ](https://github.com/grafana/github-datasource/blob/main/src/views/VariableQueryEditor.tsx)