### PR TITLE
Release 2.2.0 with fixed CI CD pipeline

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -35,3 +35,5 @@ jobs:
       environment: ${{ github.event.inputs.environment }}
       docs-only: ${{ fromJSON(github.event.inputs.docs-only) }}
       run-playwright: true
+       # skipping for now since dockerhub has some issues, TODO: enable again
+      run-playwright-with-skip-grafana-dev-image: true

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -18,3 +18,5 @@ jobs:
       golangci-lint-version: '1.64.6'
       plugin-version-suffix: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || '' }}
       run-playwright: true
+      # skipping for now since dockerhub has some issues, TODO: enable again
+      run-playwright-with-skip-grafana-dev-image: true

--- a/src/variables.test.ts
+++ b/src/variables.test.ts
@@ -58,7 +58,6 @@ describe('queryResponseToVariablesFrame', () => {
     };
 
     const result = queryResponseToVariablesFrame(query, response);
-    console.log(result);
 
     expect(result.data).toEqual([
       { value: '1', text: 'Plugin A' },


### PR DESCRIPTION
There is an ongoing incident with docker https://www.dockerstatus.com/ and our CI/CD actions fail due to dev grafana not being in docker hub (more info [here](https://raintank-corp.slack.com/archives/C01C4K8DETW/p1751971692619869)). This PR temporarily adds `run-playwright-with-skip-grafana-dev-image: true` so we can pulbish the release. 

It still tests with all of these versions (just skips the latest[ dev version](https://github.com/grafana/google-sheets-datasource/actions/runs/16141723247/job/45567115805) `12.1.0-252226` until dockehub issue is fixed):

<img width="278" alt="image" src="https://github.com/user-attachments/assets/de62f182-9813-48a4-8e15-263b2b614386" />


