### PR TITLE
Chore: Bring back dev grafana smoke tests

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -35,5 +35,3 @@ jobs:
       environment: ${{ github.event.inputs.environment }}
       docs-only: ${{ fromJSON(github.event.inputs.docs-only) }}
       run-playwright: true
-       # skipping for now since dockerhub has some issues, TODO: enable again
-      run-playwright-with-skip-grafana-dev-image: true

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -18,5 +18,3 @@ jobs:
       golangci-lint-version: '1.64.6'
       plugin-version-suffix: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || '' }}
       run-playwright: true
-      # skipping for now since dockerhub has some issues, TODO: enable again
-      run-playwright-with-skip-grafana-dev-image: true


### PR DESCRIPTION
More context in https://github.com/grafana/google-sheets-datasource/pull/340

There was an ongoing incident with docker https://www.dockerstatus.com/ and our CI/CD actions fail due to dev grafana not being in docker hub (more info [here](https://raintank-corp.slack.com/archives/C01C4K8DETW/p1751971692619869)). This [PR](https://github.com/grafana/google-sheets-datasource/pull/340) temporarily added `run-playwright-with-skip-grafana-dev-image: true` so we can pulbish the release. But this is not needed anymore, as incident has been resolved. So this PR brings back dev grafana image for smoke tests.

Fixes https://github.com/grafana/google-sheets-datasource/issues/341