### PR TITLE
Docs: replace image links in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 Visualize your Google Spreadsheets with Grafana
 
-![Visualize temperature date in Grafana Google Spreadsheets data source](https://raw.githubusercontent.com/grafana/google-sheets-datasource/main/src/docs/img/dashboard.png)
+![Visualize temperature date in Grafana Google Spreadsheets data source](https://github.com/user-attachments/assets/7857ac8e-835d-401e-b51d-3daf3d4aa89a)
 
-![Average temperatures in Google Sheets](https://raw.githubusercontent.com/grafana/google-sheets-datasource/main/src/docs/img/spreadsheet.png)
+![Average temperatures in Google Sheets](https://github.com/user-attachments/assets/218e3346-f968-495b-85ae-d29688516bba)
 
 ## Documentation
 


### PR DESCRIPTION
What?
This PR replaces broken images link in the README. 

Special notes:
I went to wayback machine to get the original images and saved and uploaded them again. I could not find in the commit history when/how they were deleted and didn't think it was necessary to re-create the original path if they can be hosted this way anyway.