### PR TITLE
chore(ci): allow releasing from tags

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -35,3 +35,4 @@ jobs:
       docs-only: ${{ fromJSON(github.event.inputs.docs-only) }}
       run-playwright: true
       github-draft-release: false
+      release-reference-regex: (main)|(v\d+\.\d+\.\d+)


### PR DESCRIPTION
Sets release-reference-regex to allow releasing both from main and semver tags with `v` prefix.

Example failure when trying to release docs from tag: https://github.com/grafana/google-sheets-datasource/actions/runs/24883561612

Docs: https://github.com/grafana/plugin-ci-workflows/blob/2fa4bd6cdd5b4e2af37100c5cbe31ce7c9a6b703/.github/workflows/cd.yml#L466-L478