### PR TITLE
Fixed a couple of awkward wordings when configuring the Google Sheets source.

### DIFF
--- a/src/components/ConfigurationHelp.tsx
+++ b/src/components/ConfigurationHelp.tsx
@@ -27,7 +27,7 @@ export const ConfigurationHelp = ({ authenticationType }: Props) => {
                 >
                   Google Sheets
                 </a>{' '}
-                in API Library and enable access for your account.
+                page in the API Library and enable access for your account.
               </li>
               <li>
                 Open the{' '}
@@ -121,7 +121,7 @@ export const ConfigurationHelp = ({ authenticationType }: Props) => {
                 >
                   Google Sheets
                 </a>{' '}
-                in API Library and enable access for your account.
+                page in the API Library and enable access for your account.
               </li>
               <li>
                 Open the{' '}
@@ -133,7 +133,7 @@ export const ConfigurationHelp = ({ authenticationType }: Props) => {
                 >
                   Google Drive
                 </a>{' '}
-                in API Library and enable access for your account. Access to the Google Drive API is used to list all
+                page in the API Library and enable access for your account. Access to the Google Drive API is used to list all
                 spreadsheets to which you have access.
               </li>
               <li>


### PR DESCRIPTION
I was creating some content with the Google Sheets plugin recently and noticed a couple of awkwardly worded sentences in the setup instructions.  This PR improves them.

I've run this locally and checked that it renders OK.