### PR TITLE
Prepare release 2.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 2.6.1
+
+🐛 Security: bump out-of-SLO react-router to 6.30.4
+
 ## 2.6.0
 
 🐛 Fix panic when a number-formatted cell has no computed value (e.g. a formula error like #DIV/0!, #N/A, #REF!)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grafana-google-sheets-datasource",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "description": "Grafana data source plugin for Google Sheets",
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",


### PR DESCRIPTION
- Bump version to `2.6.1` in `package.json`
- Update `CHANGELOG.md` with changes since [v2.6.0](https://github.com/grafana/google-sheets-datasource/releases/tag/v2.6.0) (released 2026-08-03)
- Checks: spellcheck pass; merge then run Plugins CI CD per CONTRIBUTING